### PR TITLE
Fixed VCL cookie removal logic

### DIFF
--- a/etc/fastly.vcl
+++ b/etc/fastly.vcl
@@ -94,6 +94,11 @@ sub vcl_recv {
 }
 
 sub vcl_fetch {
+
+    if (req.url ~ "^/(pub/)?(media|static)/.*") {
+        unset beresp.http.set-cookie;
+    }
+
 #FASTLY fetch
 
     if (beresp.status >= 500) {


### PR DESCRIPTION
Added code to remove set-cookies from static content to match the removal of the cookie in recv.

This alleviates a session resetting issue when a new cookie is issued from static content responses from Magento