### PR TITLE
Short cache tags, updated purging by surrogate keys so it's compatible with new tags

### DIFF
--- a/Helper/CacheTags.php
+++ b/Helper/CacheTags.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fastly\Cdn\Helper;
+
+use \Magento\Framework\App\Helper\AbstractHelper;
+
+class CacheTags extends AbstractHelper
+{
+    /**
+     * Replaces long Magento Cache tags with a shorter version
+     *
+     * @param string
+     * @return string
+     */
+    public function convertCacheTags($tags)
+    {
+        $fastlyTags = array(
+            'catalog_product' => 'p',
+            'catalog_category' => 'c',
+            'cms_page' => 'cpg'
+        );
+
+        return str_replace(array_keys($fastlyTags), $fastlyTags, $tags);
+    }
+}

--- a/Model/Layout/LayoutPlugin.php
+++ b/Model/Layout/LayoutPlugin.php
@@ -38,17 +38,25 @@ class LayoutPlugin
     protected $response;
 
     /**
+     * @var \Fastly\Cdn\Helper\CacheTags
+     */
+    protected $cacheTags;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\App\ResponseInterface $response
      * @param \Fastly\Cdn\Model\Config $config
+     * @param \Fastly\Cdn\Helper\CacheTags $cacheTags
      */
     public function __construct(
         \Magento\Framework\App\ResponseInterface $response,
-        Config $config
+        Config $config,
+        \Fastly\Cdn\Helper\CacheTags $cacheTags
     ) {
         $this->response = $response;
         $this->config = $config;
+        $this->cacheTags = $cacheTags;
     }
 
     /**
@@ -94,7 +102,7 @@ class LayoutPlugin
             // Fastly expects surrogate keys separated by space. replace existing header.
             $header = $this->response->getHeader('X-Magento-Tags');
             if ($header instanceof \Zend\Http\Header\HeaderInterface) {
-                $this->response->setHeader($header->getFieldName(), str_replace(',', ' ', $header->getFieldValue()), true);
+                $this->response->setHeader($header->getFieldName(),  $this->cacheTags->convertCacheTags(str_replace(',', ' ', $header->getFieldValue())), true);
             }
         }
         return $result;

--- a/Observer/InvalidateVarnishObserver.php
+++ b/Observer/InvalidateVarnishObserver.php
@@ -20,6 +20,7 @@
  */
 namespace Fastly\Cdn\Observer;
 
+use Fastly\Cdn\Helper\CacheTags;
 use Fastly\Cdn\Model\Config;
 use Fastly\Cdn\Model\PurgeCache;
 use Magento\Framework\Event\ObserverInterface;
@@ -39,13 +40,20 @@ class InvalidateVarnishObserver implements ObserverInterface
     protected $purgeCache;
 
     /**
+     * @var CacheTags
+     */
+    protected $cacheTags;
+
+    /**
      * @param Config $config
      * @param PurgeCache $purgeCache
+     * @param CacheTags $cacheTags
      */
-    public function __construct(Config $config, PurgeCache $purgeCache)
+    public function __construct(Config $config, PurgeCache $purgeCache, CacheTags $cacheTags)
     {
         $this->config = $config;
         $this->purgeCache = $purgeCache;
+        $this->cacheTags = $cacheTags;
     }
 
     /**
@@ -60,6 +68,7 @@ class InvalidateVarnishObserver implements ObserverInterface
             $object = $observer->getEvent()->getObject();
             if ($object instanceof \Magento\Framework\DataObject\IdentityInterface && $this->canPurgeObject($object)) {
                 foreach ($object->getIdentities() as $tag) {
+                    $tag = $this->cacheTags->convertCacheTags($tag);
                     $this->purgeCache->sendPurgeRequest($tag);
                 }
             }


### PR DESCRIPTION
Created a new helper class 'CacheTags' with a method which converts long Magento Cache tags to the short ones. The method is used to modify 'X-Magento-Tags' header and for surrogate keys. 