### PR TITLE
Update fastly.vcl

### DIFF
--- a/etc/fastly.vcl
+++ b/etc/fastly.vcl
@@ -17,6 +17,10 @@
 sub vcl_recv {
 #FASTLY recv
 
+    if (req.url ~ "^/static/version(\d*/)?(.*)$") {
+       set req.url = "/static/" + re.group.2 + "?" + re.group.1;
+    }   
+
     # auth for purging
     if (req.request == "FASTLYPURGE") {
         # extract token signature and expiration


### PR DESCRIPTION
magento suggests implementing this in nginx but it makes more sense to have it here and it won't interfere with the nginx rules, if both are used.