### PR TITLE
Tweaks to Magento-Tags shortening

### DIFF
--- a/Helper/CacheTags.php
+++ b/Helper/CacheTags.php
@@ -15,9 +15,11 @@ class CacheTags extends AbstractHelper
     public function convertCacheTags($tags)
     {
         $fastlyTags = array(
-            'catalog_product' => 'p',
-            'catalog_category' => 'c',
-            'cms_page' => 'cpg'
+            'catalog_product_' => 'p',
+            'catalog_category_' => 'c',
+            'cms_page' => 'cpg',
+            'cms_block' => 'cb',
+            'brands_brand_' => 'b'
         );
 
         return str_replace(array_keys($fastlyTags), $fastlyTags, $tags);


### PR DESCRIPTION
We need to further shorten Magento tags. In this tweak we strip off underscores for products and catalogs and shorten cms_block and brands_brand.