### PR TITLE
Don't pass static objects that have /checkout in their URL

### DIFF
--- a/etc/fastly.vcl
+++ b/etc/fastly.vcl
@@ -68,15 +68,16 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart and checkout requests
-    if (req.url ~ "/checkout") {
-        return (pass);
-    }
-
     # static files are always cacheable. remove SSL flag and cookie
     if (req.url ~ "^/(pub/)?(media|static)/.*") {
         unset req.http.Https;
         unset req.http.Cookie;
+        return (lookup);
+    }
+
+    # Bypass shopping cart and checkout requests
+    if (req.url ~ "/checkout") {
+        return (pass);
     }
 
     # geoip lookup


### PR DESCRIPTION
Move up the match for static objects, and explicitly do a lookup