### PR TITLE
Disabling afterGetIdentities interceptor

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Catalog\Model\Product">
+        <plugin name="configurable_identity" type="Magento\ConfigurableProduct\Plugin\Model\Product" disabled="true"/>
+    </type>
     <type name="Magento\PageCache\Model\Config">
         <plugin name="fastly_emulate_varnish_cache_type" type="Fastly\Cdn\Model\PageCache\ConfigPlugin"/>
     </type>


### PR DESCRIPTION
Disabling interceptor afterGetIdentities() method from Magento configurable-product module inside the Fastly extension. 