### PR TITLE
Make the pass statement more flexible

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Vcl/Upload.php
+++ b/Controller/Adminhtml/FastlyCdn/Vcl/Upload.php
@@ -120,7 +120,7 @@ class Upload extends \Magento\Backend\App\Action
                 }
             }
 
-            $condition = array('name' => Config::FASTLY_MAGENTO_MODULE.'_checkout', 'statement' => 'req.url ~ "/checkout"', 'type' => 'REQUEST', 'priority' => 90);
+            $condition = array('name' => Config::FASTLY_MAGENTO_MODULE.'_pass', 'statement' => 'req.http.x-pass', 'type' => 'REQUEST', 'priority' => 90);
             $createCondition = $this->api->createCondition($clone->number, $condition);
 
             if(!$createCondition) {

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -80,6 +80,11 @@
         set req.url = querystring.regfilter(req.url, "^(utm_.*|gclid|gdftrk|_ga|mc_.*)");
     }
     
+    # Pass on checkout URLs. Because it's a snippet we want to execute this after backend selection so we handle it
+    # in the request condition
+    if (req.url ~ "/(catalogsearch|checkout)") {
+        set req.http.x-pass = "1";
+    }
 
     # static files are always cacheable. remove SSL flag and cookie
     if (req.url ~ "^/(pub/)?(media|static)/.*") {


### PR DESCRIPTION
Since VCL snippets are always at the top of vcl_recv we can't do an early return (pass). We have solved this by adding a request condition for /checkout however Magento stock varnish passes on catalogsearch as well so instead we'll just add req.http.x-pass which will be our indicate when to pass a request.