### PR TITLE
Prevent https://www.gstatic.com/charts/loader.js URL from minification

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -44,5 +44,12 @@
                 </fastly>
             </full_page_cache>
         </system>
+        <dev>
+            <js>
+                <minify_exclude>
+                    gstatic.com
+                </minify_exclude>
+            </js>
+        </dev>
     </default>
 </config>


### PR DESCRIPTION
The fix for a dashboard graph:
When 'JS minification' is enabled in config (Stores>Configuration>Advanced>Developer>JavaScript Settings>Minify JavaScript Files = Yes), 
Magento2 tries to load all resources (that loaded via require.js) using .min.js suffix and URL, which is used for building graph (https://www.gstatic.com/charts/loader.js)
will be replaced by 'https://www.gstatic.com/charts/loader.min.js' and the customer gets 404.
Here is an example: https://github.com/magento/magento2/issues/5835#issuecomment-296290118