### PR TITLE
Magento22 compatibility

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -796,7 +796,7 @@ class Api
     /**
      * @param $uri
      * @param string $method
-     * @param string $body
+     * @param mixed[]|string $body
      * @param bool $test
      * @param $testApiKey
      * @return bool|mixed
@@ -820,26 +820,28 @@ class Api
         $options = [];
 
         // Request method specific header & option changes
-        if ($method == \Zend_Http_Client::PUT) {
-            $headers[] = 'Content-Type: application/x-www-form-urlencoded';
-            $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::PUT;
+        switch ($method) {
+            case \Zend_Http_Client::DELETE:
+                $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::DELETE;
+                break;
+            case \Zend_Http_Client::PUT:
+                $headers[] = 'Content-Type: application/x-www-form-urlencoded';
+                $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::PUT;
 
-            if ($body != '') {
-                $options[CURLOPT_POSTFIELDS] = $body;
-            }
-        }
+                if ($body != '') {
+                    $options[CURLOPT_POSTFIELDS] = $body;
+                }
 
-        if ($method == \Zend_Http_Client::DELETE) {
-            $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::DELETE;
-        }
+                break;
+            case \Zend_Http_Client::PATCH:
+                $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::PATCH;
+                $headers[] = 'Content-Type: text/json';
 
-        if ($method == \Zend_Http_Client::PATCH) {
-            $options[CURLOPT_CUSTOMREQUEST] = \Zend_Http_Client::PATCH;
-            $headers[] = 'Content-Type: text/json';
+                if ($body != '') {
+                    $options[CURLOPT_POSTFIELDS] = $body;
+                }
 
-            if ($body != '') {
-                $options[CURLOPT_POSTFIELDS] = $body;
-            }
+                break;
         }
 
         /** @var \Magento\Framework\HTTP\Adapter\Curl $client */


### PR DESCRIPTION
Bugifxes:

* Magento 2.2.x compatibility - Changes in curl wrapper caused ```CURLOPT_POSTFIELDS``` to be set twice, second time with wrong data

Other:

* Removing ```try..catch``` - curl doesn't throw one on error, and neither is any other function that was wrapped
* Using ```$headers[] = value``` instead of ```array_push()``` - it is faster and easier to read
* Using ```$client->setOptions($options);``` to set all options at once, instead of calling one by one
* Swapping ```if..elseif``` with ```switch``` due to readability of code