### PR TITLE
Add missing observers for invalidating cache upon reindex

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -20,15 +20,13 @@
  * @license     BSD, see LICENSE_FASTLY_CDN.txt
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="controller_action_postdispatch_catalog_product_save">
-        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
-    </event>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="clean_cache_after_reindex">
-        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
+        <observer name="flush_fastly_cdn" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
     </event>
     <event name="clean_cache_by_tags">
-        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
+        <observer name="flush_fastly_cdn" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
     </event>
     <event name="adminhtml_cache_flush_system">
         <observer name="flush_fastly_cdn" instance="Fastly\Cdn\Observer\FlushAllCacheObserver"/>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -21,6 +21,12 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="controller_action_postdispatch_catalog_product_save">
+        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="clean_cache_after_reindex">
+        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\FlushAllCacheObserver"/>
+    </event>
     <event name="clean_cache_by_tags">
         <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
     </event>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -22,10 +22,10 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
     <event name="controller_action_postdispatch_catalog_product_save">
-        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\FlushAllCacheObserver"/>
+        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
     </event>
     <event name="clean_cache_after_reindex">
-        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\FlushAllCacheObserver"/>
+        <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>
     </event>
     <event name="clean_cache_by_tags">
         <observer name="invalidate_varnish" instance="Fastly\Cdn\Observer\InvalidateVarnishObserver"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,6 +24,8 @@
     <module name="Fastly_Cdn" setup_version="1.0.10">
         <sequence>
             <module name="Magento_Store"/>
+            <module name="Magento_PageCache" />
+            <module name="Magento_CacheInvalidate" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Add two missing events that were causing cache invalidation not to be triggered.

Example case would be saving category info with indexing mode set to 'on schedule' and 'flat tables' being turned on.