### PR TITLE
Change in config comment: More accurate description of the action

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -120,7 +120,7 @@
                         </field>
                         <field id="purge_catalog_category" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="0" showInStore="0">
                             <label>Purge category</label>
-                            <comment>Choose to purge the whole product category when updating or modifying a single product.</comment>
+                            <comment>Choose to purge all the category assets when saving a change to that category.</comment>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         </field>
                         <field id="purge_catalog_product" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">


### PR DESCRIPTION
Original description of the action may be misleading. It was not entirely correct for the M2.1.x and the behavior differs in Magento M2.2.x. - hence the need in improving this section