### PR TITLE
Refactor cache tag adjustment logic

### DIFF
--- a/Model/Layout/LayoutPlugin.php
+++ b/Model/Layout/LayoutPlugin.php
@@ -86,18 +86,21 @@ class LayoutPlugin
                 $this->response->setHeader($header->getFieldName(), $value, true);
             }
         }
+
         # Surface the cacheability of a page. This may expose things like page blocks being set to
         # cacheable = false which makes the whole page uncacheable
         if ($subject->isCacheable() ) {
-          $this->response->setHeader("fastly-page-cacheable", "YES");
+            $this->response->setHeader("fastly-page-cacheable", "YES");
         } else {
-          $this->response->setHeader("fastly-page-cacheable", "NO");
+            $this->response->setHeader("fastly-page-cacheable", "NO");
         }
+
         return $result;
     }
 
     /**
-     * Adjust X-Magento-Tags for Fastly
+     * Add a debug header to indicate this request has passed through the Fastly Module.
+     * This is for ease of debugging
      *
      * @param \Magento\Framework\View\Layout $subject
      * @param mixed $result
@@ -106,15 +109,10 @@ class LayoutPlugin
     public function afterGetOutput(\Magento\Framework\View\Layout $subject, $result)
     {
         if ($this->config->getType() == Config::FASTLY) {
-            // Fastly expects surrogate keys separated by space. replace existing header.
-            $header = $this->response->getHeader('X-Magento-Tags');
-            if ($header instanceof \Zend\Http\Header\HeaderInterface) {
-                $this->response->setHeader($header->getFieldName(),  $this->cacheTags->convertCacheTags(str_replace(',', ' ', $header->getFieldValue())), true);
-            }
-            # Add a debug header to indicate this request has passed through the Fastly Module. This is
-            # for ease of debugging
-            $this->response->setHeader("Fastly-Module-Enabled", "1.2.28", true);
+            $this->response->setHeader("Fastly-Module-Enabled", "1.2.27", true);
         }
+
         return $result;
     }
 }
+

--- a/Model/ResponsePlugin.php
+++ b/Model/ResponsePlugin.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Fastly\Cdn\Model;
+
+use Magento\Framework\App\Response\Http;
+
+/**
+ * Fastly CDN for Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Fastly CDN for Magento End User License Agreement
+ * that is bundled with this package in the file LICENSE_FASTLY_CDN.txt.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Fastly CDN to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Fastly
+ * @package     Fastly_Cdn
+ * @copyright   Copyright (c) 2016 Fastly, Inc. (http://www.fastly.com)
+ * @license     BSD, see LICENSE_FASTLY_CDN.txt
+ */
+class ResponsePlugin
+{
+    /**
+     * @var \Fastly\Cdn\Model\Config
+     */
+    private $config;
+
+    /**
+     * @var \Fastly\Cdn\Helper\CacheTags
+     */
+    private $cacheTags;
+
+    /**
+     * ResponsePlugin constructor.
+     *
+     * @param Config $config
+     * @param \Fastly\Cdn\Helper\CacheTags $cacheTags
+     */
+    public function __construct(
+        \Fastly\Cdn\Model\Config $config,
+        \Fastly\Cdn\Helper\CacheTags $cacheTags
+    ) {
+        $this->config       = $config;
+        $this->cacheTags    = $cacheTags;
+    }
+
+    /**
+     * Alter the X-Magento-Tags header
+     *
+     * @param Http $subject
+     * @param callable $proceed
+     * @param array ...$args
+     * @return mixed
+     */
+    public function aroundSetHeader(Http $subject, callable $proceed, ...$args)
+    {
+        // Is Fastly cache enabled?
+        if ($this->config->getType() !== Config::FASTLY) {
+            return $proceed(...$args);
+        }
+
+        // Is current header X-Magento-Tags
+        if (isset($args[0]) == true && $args[0] !== 'X-Magento-Tags') {
+            return $proceed(...$args);
+        }
+
+        // Make the necessary adjustment
+        $args[1] = $this->cacheTags->convertCacheTags(str_replace(',', ' ', $args[1]));
+
+        // Proeceed
+        return $proceed(...$args);
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -20,8 +20,13 @@
  * @license     BSD, see LICENSE_FASTLY_CDN.txt
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\View\Layout">
-        <plugin name="fastly-adjust-cache-tags" type="Fastly\Cdn\Model\Layout\LayoutPlugin" sortOrder="99"/>
+        <plugin name="fastly_adjust_headers" type="Fastly\Cdn\Model\Layout\LayoutPlugin" sortOrder="99"/>
+    </type>
+
+    <type name="Magento\Framework\App\Response\Http">
+        <plugin name="fastly_adjust_cache_tags" type="Fastly\Cdn\Model\ResponsePlugin" sortOrder="100"/>
     </type>
 </config>


### PR DESCRIPTION
Unlike the default Magento Varnish setup, Fastly does not use `,` as a cache tag separator, but rather spaces. This is being adjusted in one of the plugins:

https://github.com/fastly/fastly-magento2/blob/master/Model/Layout/LayoutPlugin.php#L112

However, the code above relays on premise that output will be always rendered via layout, which is not the case for ESI blocks:

https://github.com/magento/magento2/blob/2.2.0-rc2.3/app/code/Magento/PageCache/Controller/Block/Esi.php#L16-L34

As a result, any ESI block that had more than one cache tag was not invalidated properly.

Considering the above, code has been changed to utilize the plugin around the `setHeader()` to do the changes, which covers every case(if development is done following the Magento practices)