### PR TITLE
Adjust the layout of Edge ACL admin interface

### DIFF
--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -321,10 +321,22 @@
                 </thead>
                 <tbody class="item-container">
                 <tr>
-                    <td><input name="value" data-type="acl" required="required" class="input-text admin__control-text acl-items-field" type="text"></td>
+                    <td>
+                        <input name="value" data-type="acl" data-id="" required="required" class="input-text admin__control-text dictionary-items-field" type="text">
+                    </td>
+                    <td>
+                        <div class="admin__field-option" title="'+acl_negated_title+'">
+                            <input name="negated" class="admin__control-checkbox" type="checkbox" id="acl_entry_'+ aclTimestamp +'">
+                            <label class="admin__field-label" for="acl_entry_'+ aclTimestamp +'"></label>
+                        </div>
+                    </td>
                     <td class="col-actions">
-                        <button class="action-delete fastly-save-action save_item" title="Save" type="button"><span>Save</span></button>
-                        <button class="action-delete remove_item"  title="Delete" type="button"><span>Delete</span></button>
+                        <button class="action-delete fastly-save-action save_item" title="Save" type="button">
+                            <span>Save</span>
+                        </button>
+                        <button class="action-delete remove_item"  title="Delete" type="button">
+                            <span>Delete</span>
+                        </button>
                     </td>
                 </tr>
                 </tbody>


### PR DESCRIPTION
Base template for the modal window on Edge ACL interface was missing one column, causing the JS errors and broken interface.