### PR TITLE
Checking for Auth and Tls settings creates log entries when it shouldn't

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -374,6 +374,26 @@ class Api
     }
 
     /**
+     * Performs a lookup to determine if VCL snippet exists
+     *
+     * @param string    $version    Fastly version
+     * @param string    $name   VCL snippet name
+     *
+     * @return bool
+     */
+    public function hasSnippet($version, $name)
+    {
+        $url = $this->_getApiServiceUri() . 'version/' . $version . '/snippet/' . $name;
+        $result = $this->_fetch($url, \Zend_Http_Client::GET, '', false, null, false);
+
+        if ($result == false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Deleting an individual regular VCL Snippet
      *
      * @param $version
@@ -491,16 +511,17 @@ class Api
     }
 
     /**
-     * Gets the specified Request Settings object.
+     * Retrieves a specific Request settings object.
      *
-     * @param $version
-     * @param $name
-     * @return bool|mixed
+     * @param string    $version    Fastly version
+     * @param string    $name   Request name
+     *
+     * @return bool
      */
     public function getRequest($version, $name)
     {
         $url = $this->_getApiServiceUri(). 'version/'. $version. '/request_settings/' . $name;
-        $result = $this->_fetch($url, \Zend_Http_Client::GET);
+        $result = $this->_fetch($url, \Zend_Http_Client::GET, '', false, null, false);
 
         return $result;
     }
@@ -794,15 +815,25 @@ class Api
     }
 
     /**
-     * @param $uri
-     * @param string $method
-     * @param mixed[]|string $body
-     * @param bool $test
-     * @param $testApiKey
-     * @return bool|mixed
+     * Wrapper for API calls towards Fastly service
+     *
+     * @param string    $uri    API Endpoint
+     * @param string    $method HTTP Method for request
+     * @param mixed[]|string    $body   Content
+     * @param bool  $test   Use $testApiKey for request
+     * @param string    $testApiKey API key to be tested
+     * @param bool  $logError   When set to false, prevents writing failed requests to log
+     *
+     * @return bool|mixed   Returns false on failiure
      */
-    protected function _fetch($uri, $method = \Zend_Http_Client::GET, $body = '', $test = false, $testApiKey = null)
-    {
+    protected function _fetch(
+        $uri,
+        $method = \Zend_Http_Client::GET,
+        $body = '',
+        $test = false,
+        $testApiKey = null,
+        $logError = true
+    ) {
         $apiKey = ($test == true) ? $testApiKey : $this->config->getApiKey();
 
         // Corectly format $body string
@@ -859,7 +890,10 @@ class Api
 
         // Return error based on response code
         if ($responseCode != '200') {
-            $this->logger->critical('Return status ' . $responseCode, $uri);
+            if ($logError == true) {
+                $this->logger->critical('Return status ' . $responseCode, $uri);
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Function `_fetch` which is used to do all the API calls always logs the error. However it is sometimes called and it was expected for it to fail, so logging in all scenarios doesn't make sense.