### PR TITLE
Enable browser caching of signed assets

### DIFF
--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -26,6 +26,12 @@
 
     }
 
+    # Force caching for signed cached assets.
+    if (req.http.x-long-cache) {
+        set beresp.ttl = 31536000s;
+        set beresp.http.Cache-Control = "max-age=31536000";
+    }
+
     if (beresp.http.Content-Type ~ "text/(html|xml)") {
         # enable ESI feature for Magento response by default
         esi;

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -4,9 +4,12 @@
         set req.url = re.group.2;
     }
 
+    unset req.http.x-long-cache;
+
     # Rewrite /static/versionxxxxx URLs. Avoids us having to rewrite on nginx layer
     if (req.url ~ "^/static/version(\d*/)?(.*)$") {
        set req.url = "/static/" + re.group.2 + "?" + re.group.1;
+       set req.http.x-long-cache = "1";
     }
     
     # User's Cookie may contain some Magento Vary items we should vary on


### PR DESCRIPTION
For discussion. This could live in the origin configuration too, but unfortunately we would need to remove the rewriting done in `recv.vcl` if we wanted to do that, so we might as well have the whole configuration of static asset caching live in Fastly.
