### PR TITLE
Prevent PurgeCache from triggering purge on Varnish when Fastly is used

### DIFF
--- a/Model/PageCache/PurgeCachePlugin.php
+++ b/Model/PageCache/PurgeCachePlugin.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Fastly\Cdn\Model\PageCache;
+
+use Fastly\Cdn\Model\Config;
+use Magento\CacheInvalidate\Model\PurgeCache;
+
+/**
+ * Fastly CDN for Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Fastly CDN for Magento End User License Agreement
+ * that is bundled with this package in the file LICENSE_FASTLY_CDN.txt.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Fastly CDN to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    Fastly
+ * @package     Fastly_Cdn
+ * @copyright   Copyright (c) 2016 Fastly, Inc. (http://www.fastly.com)
+ * @license     BSD, see LICENSE_FASTLY_CDN.txt
+ */
+class PurgeCachePlugin
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * PurgeCachePlugin constructor.
+     *
+     * @param Config $config
+     */
+    public function __construct(
+        Config $config
+    ) {
+        $this->config = $config;
+    }
+
+    /**
+     * Prevent Magento from executing purge requests on Varnish when Fastly is enabled
+     *
+     * @param PurgeCache $subject
+     * @param callable $proceed
+     * @param array ...$args
+     */
+    public function aroundSendPurgeRequest(PurgeCache $subject, callable $proceed, ...$args)
+    {
+        if ($this->config->isFastlyEnabled() !== true) {
+            $proceed(...$args);
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -27,6 +27,9 @@
     <type name="Magento\PageCache\Model\Config">
         <plugin name="fastly_emulate_varnish_cache_type" type="Fastly\Cdn\Model\PageCache\ConfigPlugin"/>
     </type>
+    <type name="Magento\CacheInvalidate\Model\PurgeCache">
+        <plugin name="fastly_disable_varnish_calls" type="Fastly\Cdn\Model\PageCache\PurgeCachePlugin" />
+    </type>
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
Bugfix: When Fastly extension is turned on, Varnish purge calls are still being sent