### PR TITLE
Adding few VCL optimizations

### DIFF
--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -16,7 +16,7 @@
 
     # Remove Set-Cookies from responses for static content
     # to match the cookie removal in recv.
-    if (req.url ~ "^/(pub/)?(media|static)/") {
+    if (req.http.x-long-cache || req.url ~ "^/(pub/)?(media|static)/") {
         unset beresp.http.set-cookie;
 
         # Set a short TTL for 404's since those can be temporary during the site build/index
@@ -46,8 +46,8 @@
         # compress it
         set beresp.http.x-compress-hint = "on";
     } else {
-        # enable gzip for all static content
-        if (http_status_matches(beresp.status, "200,404") && (beresp.http.content-type ~ "^(application\/x\-javascript|text\/css|application\/javascript|text\/javascript|application\/json|application\/vnd\.ms\-fontobject|application\/x\-font\-opentype|application\/x\-font\-truetype|application\/x\-font\-ttf|application\/xml|font\/eot|font\/opentype|font\/otf|image\/svg\+xml|image\/vnd\.microsoft\.icon|text\/plain)\s*($|;)" || req.url.ext ~ "(?i)(css|js|html|eot|ico|otf|ttf|json)" ) ) {
+        # enable gzip for all static content except 
+        if ( !req.http.x-long-cache && http_status_matches(beresp.status, "200,404") && (beresp.http.content-type ~ "^(application\/x\-javascript|text\/css|application\/javascript|text\/javascript|application\/json|application\/vnd\.ms\-fontobject|application\/x\-font\-opentype|application\/x\-font\-truetype|application\/x\-font\-ttf|application\/xml|font\/eot|font\/opentype|font\/otf|image\/svg\+xml|image\/vnd\.microsoft\.icon|text\/plain)\s*($|;)" || req.url.ext ~ "(?i)(css|js|html|eot|ico|otf|ttf|json)" ) ) {
             # always set vary to make sure uncompressed versions dont always win
             if (!beresp.http.Vary ~ "Accept-Encoding") {
                 if (beresp.http.Vary) {

--- a/etc/vcl_snippets/miss.vcl
+++ b/etc/vcl_snippets/miss.vcl
@@ -1,2 +1,5 @@
-    # Deactivate gzip on origin
-    unset bereq.http.Accept-Encoding;
+    # Deactivate gzip on origin. This is so we can make sure that ESI fragments
+    # come uncompressed. X-Long-Cache objects can be left untouched.
+    if ( !req.http.x-long-cache ) {
+        unset bereq.http.Accept-Encoding;
+    }

--- a/etc/vcl_snippets/pass.vcl
+++ b/etc/vcl_snippets/pass.vcl
@@ -1,5 +1,8 @@
-    # Deactivate gzip on origin
-    unset bereq.http.Accept-Encoding;
+    # Deactivate gzip on origin. This is so we can make sure that ESI fragments
+    # come uncompressed. X-Long-Cache objects can be left untouched.
+    if ( !req.http.x-long-cache ) {
+        unset bereq.http.Accept-Encoding;
+    }
 
     # Increase first byte timeouts for /admin* URLs to 3 minutes
     if ( req.url ~ "^/(index\.php/)?admin(_.*)?/" ) {

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -81,7 +81,7 @@
     
     # Pass on checkout URLs. Because it's a snippet we want to execute this after backend selection so we handle it
     # in the request condition
-    if (req.url ~ "/(catalogsearch|checkout|customer/section/load)") {
+    if (!req.http.x-long-cache && req.url ~ "/(catalogsearch|checkout|customer/section/load)") {
         set req.http.x-pass = "1";
     # Pass all admin actions
     } else if ( req.url ~ "^/(index\.php/)?admin(_.*)?/" ) {
@@ -94,7 +94,7 @@
 
 
     # static files are always cacheable. remove SSL flag and cookie
-    if (req.url ~ "^/(pub/)?(media|static)/.*") {
+    if (req.http.x-long-cache || req.url ~ "^/(pub/)?(media|static)/.*") {
         unset req.http.Https;
         unset req.http.Cookie;
     }


### PR DESCRIPTION
1. By default so far we were requesting all objects from origin uncompressed then
recompressing. This commit avoids compressing version static assets that are
available in /static/version and lets origin do it
2. There was a bug if a URL had /checkout/ anywhere in the URL we'd pass the URL.
Condition was added not to pass if URL is from /static/version