### PR TITLE
Feature/send backtrace on purgeall

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -174,7 +174,7 @@ class Api
                 $trace[] = "#{$row} {$data['file']}:{$data['line']} -> {$data['function']}()";
             }
 
-            $this->sendWebHook('*Pruge all backtrace:*```' .  implode("\n", $trace) . '```');
+            $this->sendWebHook('*Purge all backtrace:*```' .  implode("\n", $trace) . '```');
         }
 
         return $result;

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -163,6 +163,18 @@ class Api
 
         if ($this->config->areWebHooksEnabled() && $this->config->canPublishPurgeAllChanges()) {
             $this->sendWebHook('*initiated clean/purge all*');
+
+            if ($this->config->canPublishDebugBacktrace() == false) {
+                return $result;
+            }
+            
+            $stackTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            $trace = [];
+            foreach ($stackTrace as $row => $data) {
+                $trace[] = "#{$row} {$data['file']}:{$data['line']} -> {$data['function']}()";
+            }
+
+            $this->sendWebHook('*Pruge all backtrace:*```' .  implode("\n", $trace) . '```');
         }
 
         return $result;

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -172,6 +172,11 @@ class Config extends \Magento\PageCache\Model\Config
     const XML_FASTLY_PUBLISH_PURGE_ALL_EVENTS = 'system/full_page_cache/fastly/fastly_web_hooks/publish_purge_all_items_events';
 
     /**
+     * XML path to enable Publish Purge All/Clean backtrace
+     */
+    const XML_FASTLY_PUBLISH_PURGE_ALL_TRACE = 'system/full_page_cache/fastly/fastly_web_hooks/publish_purge_all_trace';
+
+    /**
      * XML path to enable Publish Config change events
      */
     const XML_FASTLY_PUBLISH_CONFIG_CHANGE_EVENTS = 'system/full_page_cache/fastly/fastly_web_hooks/publish_config_change_events';
@@ -399,6 +404,16 @@ class Config extends \Magento\PageCache\Model\Config
     public function canPublishPurgeAllChanges()
     {
         return ($this->isEnabled() && $this->_scopeConfig->isSetFlag(self::XML_FASTLY_PUBLISH_PURGE_ALL_EVENTS));
+    }
+
+    /**
+     * Is publishing backtrace on purgall allowed
+     *
+     * @return bool
+     */
+    public function canPublishDebugBacktrace()
+    {
+        return ($this->isEnabled() && $this->_scopeConfig->isSetFlag(self::XML_FASTLY_PUBLISH_PURGE_ALL_TRACE));
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -213,6 +213,14 @@
                                 <field id="enable_webhooks">1</field>
                             </depends>
                         </field>
+                        <field id="publish_purge_all_trace" translate="label comment" type="select" sortOrder="32" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Publish stack trace on purge all event</label>
+                            <comment>Submits the stack trace when the purge all event is created, for debugging purposes</comment>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <depends>
+                                <field id="enab2le_webhooks">1</field>
+                            </depends>
+                        </field>
                         <field id="publish_config_change_events" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Publish Config change events</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -218,7 +218,7 @@
                             <comment>Submits the stack trace when the purge all event is created, for debugging purposes</comment>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <depends>
-                                <field id="enab2le_webhooks">1</field>
+                                <field id="enable_webhooks">1</field>
                             </depends>
                         </field>
                         <field id="publish_config_change_events" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -40,6 +40,7 @@
                         <enable_webhooks>0</enable_webhooks>
                         <publish_key_url_purge_events>1</publish_key_url_purge_events>
                         <publish_purge_all_items_events>1</publish_purge_all_items_events>
+                        <publish_purge_all_trace>0</publish_purge_all_trace>
                         <publish_config_change_events>1</publish_config_change_events>
                     </fastly_web_hooks>
                 </fastly>


### PR DESCRIPTION
For debugging purposes, enable sending _full stack trace_ on **purge all** event via Slack integration.