### PR TITLE
Bugfix/double purge admin

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -59,6 +59,11 @@ class Api
     protected $log;
 
     /**
+     * @var bool Purge all flag
+     */
+    protected $purged = false;
+
+    /**
      * Api constructor.
      * @param Config $config
      * @param CurlFactory $curlFactory
@@ -150,12 +155,18 @@ class Api
     }
 
     /**
-     * Purge all of Fastly's CDN content
+     * Purge all of Fastly's CDN content. Can be called only once per request
      *
      * @return bool
      */
     public function cleanAll()
     {
+        // Check if purge has been requested on this request
+        if ($this->purged == true) {
+            return true;
+        }
+        $this->purged = true;
+
         $uri = $this->_getApiServiceUri() . 'purge_all';
         if ($result = $this->_purge($uri)) {
             $this->logger->execute('clean all items');


### PR DESCRIPTION
Following has been modified:

* Allow only single call to purge all per request
*  When using action from admin to purge Magento&Fastly cache, remove _full_page_ from the list of available cache types, as it is handled separately