### PR TITLE
Bugfix/shorten cache tags

### DIFF
--- a/Helper/CacheTags.php
+++ b/Helper/CacheTags.php
@@ -15,18 +15,19 @@ class CacheTags extends AbstractHelper
     public function convertCacheTags($tags)
     {
         $fastlyTags = array(
-            // <= 2.1.*
+            // 2.1.*
             'catalog_product_' => 'p',
             'catalog_category_' => 'c',
             'cms_page' => 'cpg',
             'cms_block' => 'cb',
 
-            // > 2.2.*
+            // 2.2.*
             'cat_p_' => 'p',
             'cat_c_' => 'c',
             'cms_p' => 'cpg',
             'cms_b' => 'cb',
 
+            // Other
             'brands_brand_' => 'b'
         );
 

--- a/Helper/CacheTags.php
+++ b/Helper/CacheTags.php
@@ -15,10 +15,18 @@ class CacheTags extends AbstractHelper
     public function convertCacheTags($tags)
     {
         $fastlyTags = array(
+            // <= 2.1.*
             'catalog_product_' => 'p',
             'catalog_category_' => 'c',
             'cms_page' => 'cpg',
             'cms_block' => 'cb',
+
+            // > 2.2.*
+            'cat_p_' => 'p',
+            'cat_c_' => 'c',
+            'cms_p' => 'cpg',
+            'cms_b' => 'cb',
+
             'brands_brand_' => 'b'
         );
 


### PR DESCRIPTION
Magento 2.2.* comes with different naming convention for tags