### PR TITLE
Prevent https://www.gstatic.com/charts/loader.js URL from minification

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -54,5 +54,12 @@
                 </fastly>
             </full_page_cache>
         </system>
+        <dev>
+            <js>
+                <minify_exclude>
+                    gstatic.com
+                </minify_exclude>
+            </js>
+        </dev>
     </default>
 </config>


### PR DESCRIPTION
This PR is a duplicate of the #91 which was overridden by @tnikcevs in #92 

The fix for a dashboard graph:
When 'JS minification' is enabled in config (Stores>Configuration>Advanced>Developer>JavaScript Settings>Minify JavaScript Files = Yes),
Magento2 tries to load all resources (that loaded via require.js) using .min.js suffix and URL, which is used for building graph (https://www.gstatic.com/charts/loader.js)
will be replaced by 'https://www.gstatic.com/charts/loader.min.js' and the customer gets 404.
Here is an example: magento/magento2#5835 (comment)