### PR TITLE
Add canvas parameter to product images

### DIFF
--- a/Model/Product/Image.php
+++ b/Model/Product/Image.php
@@ -195,6 +195,9 @@ class Image extends ImageModel
 
         $this->fastlyParameters['width'] = $this->_width;
         $this->fastlyParameters['height'] = $this->_height;
+
+        // Make sure Fastly delivers the specified size, even with letterboxing or pillarboxing.
+        $this->fastlyParameters['canvas'] = "{$this->_width},{$this->_height}";
     }
 
     /**


### PR DESCRIPTION
### Change description:
We noticed an issue with the fastly-magento2 module when Deep Image Optimization is enabled. Product images are being delivered that aren't exactly matching the requested size, causing issues with Magento 2 templates.

This code proposal changes the fastly-magento2 module request a canvas size equal to the target product image size. Aspect ratio is maintained, just like before.

Example product image URL without this change: 
`lower_manhattan_from_empire_state_building.jpg?width=88&height=110&quality=80&bg-color=255,255,255&fit=bounds `

Example product image URL with this change:
`lower_manhattan_from_empire_state_building.jpg?width=88&height=110&quality=80&bg-color=255,255,255&fit=bounds&canvas=88,110`

Adding empty pixels using formats without an alpha channel requires picking a background color, and this is supported by the built-in image resizers. Conveniently, the background color is already being specified in the URL parameters sent by the fastly-magento2 module without making any changes to the code.

If the addition of the canvas parameter should be in another method or should be implemented in a different way, please let me know.

### Why this change is needed:
Fastly Deep Image Optimization, as configured by the fastly-magento2 module, delivers product images that are cropped to remove empty canvas space. This causes issues with store themes.

Deep image optimization disabled:
![image_optimization_disabled_product_nav_wrap](https://user-images.githubusercontent.com/12436335/45500265-e657b680-b743-11e8-8626-3f0b2d4a47b2.png)

Deep image optimization enabled:
![image_optimization_enabled_product_nav_wrap](https://user-images.githubusercontent.com/12436335/45500248-d9d35e00-b743-11e8-976d-7ad32a6e9621.png)

Deep image optimization disabled (open the image in a new tab to see the difference):
![pigments_deep_io_disabled](https://user-images.githubusercontent.com/12436335/45501225-35065000-b746-11e8-962c-8bc32a3a7f4d.jpg)

Deep image optimization enabled (open the image in a new tab to see the difference):
![pigments_deep_io_enabled](https://user-images.githubusercontent.com/12436335/45501229-36d01380-b746-11e8-83bb-196dd7e90c63.jpg)

The built-in Magento 2 image resizers based on ImageMagick and GD2 behave differently than the fastly-magento2 module with Deep Image Optimization enabled. With both built-in and Deep Image Optimization resizers, product images are resized to fit entirely within a target height and width. Also, they both preserve the aspect ratio of the source image to avoid distortion. The difference is that the built-in resizers add empty space to either the top and bottom or the left and right so that the canvas size exactly matches the target height and width. 

The current Deep Image Optimization behavior causes template issues because of templates scaling product images by changing their shortest edge to match their container. The problem is images delivered to the browser in this way can be smaller than the image that's ultimately displayed. This results in images that are first scaled down only to be scaled up again. This can look pretty bad depending on how much upscaling is performed.

There's an edge case when the source image and the image container size have the exact same aspect ratio. When this happens, no upscaling is performed by the template and the resulting image looks fine. This is demonstrated in the examples above by the picture of the duffel bag. In every other case, the problem occurs.

I tested this change with several different Magento 2 themes, though I was unable to test any paid themes. In all cases, the problem is present with the original fastly-magento2 module and goes away with both the built-in resizers and with the modified Fastly module.