### PR TITLE
Add store code to CountryMapping list to identify store

### DIFF
--- a/Block/System/Config/Form/Field/CountryMapping.php
+++ b/Block/System/Config/Form/Field/CountryMapping.php
@@ -105,7 +105,7 @@ class CountryMapping extends AbstractFieldArray
         foreach ($this->_storeManager->getStores() as $store) {
             $options[] = [
                 'value' => $store->getId(),
-                'label' => $store->getName()
+                'label' => $store->getName() . " [" . $store->getCode() . "]"
             ];
         }
 


### PR DESCRIPTION
When selecting a new GeoIP mapping for a country, only the store name is shown, as this can be the language to select the list can be filled with a lot of the same names making it hard to select the correct store. By adding the storecode to the label its easier to select the correct store.