### PR TITLE
Stop rewriting version assets URLs in Varnish

### DIFF
--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -7,7 +7,7 @@
     unset req.http.x-long-cache;
 
     # We want to force long cache times on any of the versioned assets
-    if (req.url.path ~ "^/static/version(\d*/)") {
+    if (req.url.path ~ "^/static/version\d*/") {
        set req.http.x-long-cache = "1";
     }
     

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -6,9 +6,8 @@
 
     unset req.http.x-long-cache;
 
-    # Rewrite /static/versionxxxxx URLs. Avoids us having to rewrite on nginx layer
-    if (req.url ~ "^/static/version(\d*/)?(.*)$") {
-       set req.url = "/static/" + re.group.2 + "?" + re.group.1;
+    # We want to force long cache times on any of the versioned assets
+    if (req.url.path ~ "^/static/version(\d*/)") {
        set req.http.x-long-cache = "1";
     }
     


### PR DESCRIPTION
Rewriting version assets URLs was committed in this commit

https://github.com/fastly/fastly-magento2/commit/cb8159d9a45534a14d8b70b7da61db0c4cc8df33

Unfortunately this appears to breaks certain workflows and ultimately doesn't appear us it buys us too much. This commit undoes the rewriting.

Risk: Users who have undone the rewriting on nginx