### PR TITLE
Fix issue with undefined $url in catch{} when exception happens in first line of try{}

### DIFF
--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -153,8 +153,8 @@ class Notification extends Feed
     public function getLastVersion()
     {
         try {
-            $client = $this->curlFactory->create();
             $url = self::CHECK_VERSION_URL;
+            $client = $this->curlFactory->create();
 
             $client->write(\Zend_Http_Client::GET, $url, '1.1');
             $responseBody = $client->read();


### PR DESCRIPTION
When exception happens in first line of try{}, as it happened to me today, then catch{} block uses variable $url that was not defined yet.