### PR TITLE
Fix GeoIP not working for stores with different base URL

### DIFF
--- a/Controller/GeoIP/GetAction.php
+++ b/Controller/GeoIP/GetAction.php
@@ -127,6 +127,7 @@ class GetAction extends Action
                 $currentStore = $this->storeManager->getStore();
                 // only generate a redirect URL if current and new store are different
                 if ($currentStore->getId() != $targetStore->getId()) {
+                    $this->url->setScope($targetStore->getId());
                     $this->url->addQueryParams([
                         '___store'      => $targetStore->getCode(),
                         '___from_store' => $currentStore->getCode()


### PR DESCRIPTION
Currently when the GeoIP redirect URL is generated, it is done in the context of the current store. This means that if the target store has a different base URL to that of the current store, the generated redirect URL is incorrect. When the user is then redirected to the URL, the switch fails as it isn't using the target store's base URL.

This can be fixed by setting the scope of the URL builder to the target store, so that it uses the base URL of the target store to build the redirect URL.