### PR TITLE
Removed string type hint from constructor, added phpdoc comment

### DIFF
--- a/Model/View/Asset/Image.php
+++ b/Model/View/Asset/Image.php
@@ -89,7 +89,7 @@ class Image extends ImageModel
      * @param ScopeConfigInterface $scopeConfig
      * @param ImageHelper $imageHelper
      * @param StoreManagerInterface $storeManager
-     * @param $filePath
+     * @param string $filePath
      * @param array $miscParams
      */
     public function __construct(
@@ -99,7 +99,7 @@ class Image extends ImageModel
         ScopeConfigInterface $scopeConfig,
         ImageHelper $imageHelper,
         StoreManagerInterface $storeManager,
-        string $filePath,
+        $filePath,
         array $miscParams
     ) {
         $this->scopeConfig = $scopeConfig;


### PR DESCRIPTION
This change should stop the setup:di:compile error by setting the variable type as string in the phpdoc comment _@param **string** $filePath_ and also prevent the checkout page error by removing the _**string**_ type hint from the constructor parameter