### PR TITLE
Ignore Listrak query parameters by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,7 +30,7 @@
                         <stale_ttl>86400</stale_ttl>
                         <stale_error_ttl>86400</stale_error_ttl>
                         <admin_path_timeout>180</admin_path_timeout>
-                        <ignored_url_parameters>utm_.*, gclid, gdftrk, _ga, mc_.*</ignored_url_parameters>
+                        <ignored_url_parameters>utm_.*, gclid, gdftrk, _ga, mc_.*, trk_.*</ignored_url_parameters>
                         <preserve_static>1</preserve_static>
                         <soft_purge>1</soft_purge>
                         <x_magento_tags_size>16383</x_magento_tags_size>


### PR DESCRIPTION
Listrak appends:

- trk_contact (Definitely unique)
- trk_sid (Definitely unique)

They also append:

- trk_msg
- trk_module

This change strips them out by default