### PR TITLE
DI is broken due to missed argument type

### DIFF
--- a/Model/View/Asset/Image.php
+++ b/Model/View/Asset/Image.php
@@ -109,7 +109,7 @@ class Image extends ImageModel
      * @param StoreManagerInterface $storeManager
      * @param File $file
      * @param Filesystem $filesystem
-     * @param $filePath
+     * @param string $filePath
      * @param array $miscParams
      */
     public function __construct(


### PR DESCRIPTION
# Preconditions

* Magento is in Production mode or Magento Cloud
* Run `setup:di:compile -vvv`

# Expected result

* DI is successful

# Actual result

* DI is failing with

```
Compilation was started.
Interception cache generation... 6/7 [========================>---]  85% 3 mins 512.0 MiBErrors during compilation:
        Fastly\Cdn\Model\View\Asset\Image
                Incompatible argument type: Required type: string. Actual type: \Fastly\Cdn\Model\View\Asset\filePath; File: 
/Users/olehposyniak/www/testing2/vendor/fastly/magento2/Model/View/Asset/Image.php

Total Errors Count: 1

In Log.php line 92:
```