### PR TITLE
Compatibility with images served from S3 with Fastly IO

### DIFF
--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -85,8 +85,10 @@
         return (pass);
     }
 
-    # Varnish sets default TTL if none of these are present. If not set we want to make sure we don't cache it
-    if (!beresp.http.Expires && !beresp.http.Surrogate-Control ~ "max-age" && !beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
+    if (beresp.http.x-amz-request-id) {
+        # media retrieved from Amazon S3 should be cacheable even with Shielding enabled
+    } else if (!beresp.http.Expires && !beresp.http.Surrogate-Control ~ "max-age" && !beresp.http.Cache-Control ~ "(s-maxage|max-age)") {
+        # Varnish sets default TTL if none of the headers above are present. If not set we want to make sure we don't cache it
         set beresp.ttl = 0s;
         set beresp.cacheable = false;
     }


### PR DESCRIPTION
At Magento we are working on the feature that allows to serve images from S3 directly and cache them on Fastly side. Image optimization is also offloaded to Fastly.

Currently, Fastly image optimization works with images served by Magento backend, but does not with images served from S3 backend due to missing cache-control headers.

Proposed patch will make Fastly cache all responses from S3, even those which do not contain cache-control headers.

If you see more elegant way of solving the described issue, please share.