### PR TITLE
Due to changes how Fastly terminates TLS traffic we need to make sure…

### DIFF
--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -23,7 +23,7 @@
         remove resp.http.fastly-page-cacheable;
     }
 
-    # debug info
+    # X-Magento-Debug header is exposed when developer mode is activated in Magento
     if (!resp.http.X-Magento-Debug) {
         # remove Varnish/proxy header
         remove resp.http.X-Magento-Debug;

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -7,6 +7,11 @@
     if ( fastly.ff.visits_this_service == 0 ) {
         # Remove X-Magento-Vary and HTTPs Vary served to the user
         set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https", "Cookie");
+        # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
+        # compress it and we only want to do this on the edge nodes
+        if (resp.http.x-esi) {
+            set resp.http.x-compress-hint = "on";
+        }
         remove resp.http.X-Magento-Tags;
     }
 

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -40,19 +40,12 @@
     if (beresp.http.x-esi) {
         # enable ESI feature for Magento response by default
         esi;
-        # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
-        # compress it
-        set beresp.http.x-compress-hint = "on";
     } else {
         # enable gzip for all static content except
         if ( http_status_matches(beresp.status, "200,404") && (beresp.http.content-type ~ "^(application\/x\-javascript|text\/css|text\/html|application\/javascript|text\/javascript|application\/json|application\/vnd\.ms\-fontobject|application\/x\-font\-opentype|application\/x\-font\-truetype|application\/x\-font\-ttf|application\/xml|font\/eot|font\/opentype|font\/otf|image\/svg\+xml|image\/vnd\.microsoft\.icon|text\/plain)\s*($|;)" || req.url.ext ~ "(?i)(css|js|html|eot|ico|otf|ttf|json)" ) ) {
             # always set vary to make sure uncompressed versions dont always win
             if (!beresp.http.Vary ~ "Accept-Encoding") {
-                if (beresp.http.Vary) {
-                    set beresp.http.Vary = beresp.http.Vary ", Accept-Encoding";
-                } else {
-                    set beresp.http.Vary = "Accept-Encoding";
-                }
+                set beresp.http.Vary:Accept-Encoding = "";
             }
             if (req.http.Accept-Encoding == "gzip") {
                 set beresp.gzip = true;


### PR DESCRIPTION
… we only set

x-compress-hint on edge requests as that may affect ESI processing. This change
set x-compress-hint only on the edge nodes.