### PR TITLE
M095M01A-3 [Magento 2] Hide API token

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -46,7 +46,7 @@
                     <!-- ================================
                          Fastly API Token input field
                     ================================= -->
-                    <field id="fastly_api_key" type="text" translate="label comment" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <field id="fastly_api_key" type="password" translate="label comment" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                         <label>Fastly API Token</label>
                         <comment>
                             <![CDATA[Please create a <a href="https://manage.fastly.com/account/personal/tokens" target="_blank">Fastly API token</a> with a global scope.<br /><br />


### PR DESCRIPTION
- Changed field type to "password" for `fastly_api_key`