### PR TITLE
feature/M095M01A-12 [MAGENTO 2] Command line interface broken

### DIFF
--- a/Console/Command/EnableCommand.php
+++ b/Console/Command/EnableCommand.php
@@ -24,6 +24,7 @@ use Fastly\Cdn\Model\Config;
 use Fastly\Cdn\Model\Api;
 use Fastly\Cdn\Helper\Vcl;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -385,6 +386,9 @@ class EnableCommand extends Command
         if ($input->getOption('cache')) {
             $this->cleanCache();
         }
+
+        $arguments = new ArrayInput(['command' => 'cache:flush', 'types' => ['config']]);
+        $this->getApplication()->find('cache:flush')->run($arguments, $output);
     }
 
     /**


### PR DESCRIPTION
- Added call to `cache:flush config` to the end of `fastly:config:set`, so that following commands use the update values always.