### PR TITLE
improve message format. eliminated '+' operator for embedding variables

### DIFF
--- a/view/adminhtml/web/js/backends.js
+++ b/view/adminhtml/web/js/backends.js
@@ -193,7 +193,7 @@ define([
                 showLoader: true,
                 success: function (response) {
                     if (response.status === true) {
-                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "'+backend_name+'" is successfully updated.')).show();
+                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "%1" is successfully updated.').replace('%1', backend_name)).show();
                         active_version = response.active_version;
                         backendModal.modal('closeModal');
                         getBackends(active_version, false).done(function (resp) {
@@ -288,7 +288,7 @@ define([
                 showLoader: true,
                 success: function (response) {
                     if (response.status === true) {
-                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "'+backendName+'" is successfully created.')).show();
+                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "%1" is successfully created.').replace('%1', backendName)).show();
                         active_version = response.active_version;
                         backendModal.modal('closeModal');
                         $('#fastly_add_backend_button').remove();
@@ -355,7 +355,7 @@ define([
                 showLoader: true,
                 success: function (response) {
                     if (response.status === true) {
-                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "'+backend_name+'" was successfully deleted.')).show();
+                        $('#fastly-success-backend-button-msg').text($.mage.__('Backend "%1" was successfully deleted.').replace('%1', backend_name)).show();
                         active_version = response.active_version;
                         $('.loading-backends').show();
                         $('#fastly-backends-list').html('');
@@ -631,7 +631,7 @@ define([
                         oldName = $('#backend_name').val();
                         $('.upload-button span').text('Update');
                         backend_name = backends[backend_id].name;
-                        $('.modal-title').text($.mage.__('Backend "'+backend_name+'" configuration'));
+                        $('.modal-title').text($.mage.__('Backend "%1" configuration').replace('%1', backend_name));
                     }
                 });
             });

--- a/view/adminhtml/web/js/basic-authentication.js
+++ b/view/adminhtml/web/js/basic-authentication.js
@@ -240,7 +240,7 @@ define([
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successAuthBtnMsg.text($.mage.__('Basic Authentication is successfully ' + disabledOrEnabled + '.')).show();
+                        successAuthBtnMsg.text($.mage.__('Basic Authentication is successfully %1.').replace('%1', disabledOrEnabled)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             authStateMsgSpan.find('#auth_state_disabled').hide();

--- a/view/adminhtml/web/js/basic-authentication.js
+++ b/view/adminhtml/web/js/basic-authentication.js
@@ -233,14 +233,16 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (authStatus === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successAuthBtnMsg.text($.mage.__('Basic Authentication is successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successAuthBtnMsg.text($.mage.__('Basic Authentication is successfully %1.').replace('%1', statusStr)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             authStateMsgSpan.find('#auth_state_disabled').hide();

--- a/view/adminhtml/web/js/blocking.js
+++ b/view/adminhtml/web/js/blocking.js
@@ -220,14 +220,16 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (blocking === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successBlockingBtnMsg.text($.mage.__('Blocking is successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successBlockingBtnMsg.text($.mage.__('Blocking is successfully %1.').replace('%1', statusStr)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             blockingStateMsgSpan.find('#blocking_state_disabled').hide();

--- a/view/adminhtml/web/js/blocking.js
+++ b/view/adminhtml/web/js/blocking.js
@@ -227,7 +227,7 @@ define([
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successBlockingBtnMsg.text($.mage.__('Blocking is successfully ' + disabledOrEnabled + '.')).show();
+                        successBlockingBtnMsg.text($.mage.__('Blocking is successfully %1.').replace('%1', disabledOrEnabled)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             blockingStateMsgSpan.find('#blocking_state_disabled').hide();

--- a/view/adminhtml/web/js/custom-synthetic-pages.js
+++ b/view/adminhtml/web/js/custom-synthetic-pages.js
@@ -87,7 +87,7 @@ define([
             }
             let errorHtmlChars = $('#error_page_html').val().length;
             if (errorHtmlChars >= maxChars) {
-                msgWarning.text($.mage.__('The HTML must contain less than ' + maxChars + ' characters. Current number of characters: ' + errorHtmlChars));
+                msgWarning.text($.mage.__('The HTML must contain less than %1 characters. Current number of characters: %2').replace('%1', maxChars).replace('%2',errorHtmlChars));
                 msgWarning.show();
                 return;
             }
@@ -126,7 +126,7 @@ define([
             }
             let wafHtmlChars = $('#waf_page_content').val().length;
             if (wafHtmlChars >= maxChars) {
-                msgWarning.text($.mage.__('The content must contain less than ' + maxChars + ' characters. Current number of characters: ' + wafHtmlChars));
+                msgWarning.text($.mage.__('The content must contain less than %1 characters. Current number of characters: %2').replace('%1', maxChars).replace('%2', wafHtmlChars));
                 msgWarning.show();
                 return;
             }

--- a/view/adminhtml/web/js/edge-acl.js
+++ b/view/adminhtml/web/js/edge-acl.js
@@ -391,7 +391,7 @@ define([
                     }
 
                     overlay(aclItemOptions);
-                    $('.modal-title').text($.mage.__('"'+ acl_name +'" ACL container items'));
+                    $('.modal-title').text($.mage.__('"%1" ACL container items').replace('%1', acl_name));
                     $('.upload-button').remove();
 
                     $('#acl-items-table > tbody').html(itemsHtml);
@@ -545,8 +545,8 @@ define([
                     overlay(aclDeleteContainerOptions);
                     setServiceLabel(active_version, next_version, service_name);
                     let containerWarning = $('#fastly-container-warning');
-                    $('.modal-title').text($.mage.__('Delete "'+ acl_id +'" ACL container'));
-                    containerWarning.text($.mage.__('You are about to delete the "' + acl_id + '" ACL container.'));
+                    $('.modal-title').text($.mage.__('Delete "%1" ACL container').replace('%1', acl_id));
+                    containerWarning.text($.mage.__('You are about to delete the "%1" ACL container.').replace('%1', acl_id));
                     containerWarning.show();
                     if (aclHtml !== '') {
                         $('#delete-acl-container').html(aclHtml);

--- a/view/adminhtml/web/js/edge-dictionaries.js
+++ b/view/adminhtml/web/js/edge-dictionaries.js
@@ -359,7 +359,7 @@ define([
                     }
 
                     overlay(dictionaryItemOptions);
-                    $('.modal-title').text($.mage.__('"'+ dictionary_name +'" dictionary container items'));
+                    $('.modal-title').text($.mage.__('"%1" dictionary container items').replace('%1', dictionary_name));
                     $('.upload-button').remove();
 
                     $('#dictionary-items-table > tbody').html(itemsHtml);
@@ -468,8 +468,8 @@ define([
                     overlay(dictionaryDeleteContainerOptions);
                     setServiceLabel(active_version, next_version, service_name);
                     let containerWarning = $('#fastly-container-warning');
-                    $('.modal-title').text($.mage.__('Delete "'+ dictionary_id +'" Dictionary container'));
-                    containerWarning.text($.mage.__('You are about to delete the "' + dictionary_id + '" Dictionary container.'));
+                    $('.modal-title').text($.mage.__('Delete "%1" Dictionary container').replace('%1', dictionary_id));
+                    containerWarning.text($.mage.__('You are about to delete the "%1" Dictionary container.').replace('%1', dictionary_id));
                     containerWarning.show();
                     if (dictionaryHtml !== '') {
                         $('#delete-dictionary-container').html(dictionaryHtml);

--- a/view/adminhtml/web/js/image-optimization.js
+++ b/view/adminhtml/web/js/image-optimization.js
@@ -234,7 +234,7 @@ define([
                         ioSnippetStatus = false;
                     }
 
-                    successIoBtnMsg.text($.mage.__('The Image Optimization snippet has been successfully ' + toggled + '.')).show();
+                    successIoBtnMsg.text($.mage.__('The Image Optimization snippet has been successfully %1.').replace('%1', toggled)).show();
                     $('.request_imgopt_state_span').hide();
 
                     if (ioSnippetStatus === true) {

--- a/view/adminhtml/web/js/image-optimization.js
+++ b/view/adminhtml/web/js/image-optimization.js
@@ -224,13 +224,16 @@ define([
             }).done(function (response) {
                 if (response.status === true) {
                     let toggled;
+                    let statusStr;
                     modal.modal('closeModal');
 
                     if (ioSnippetStatus === false) {
                         toggled = 'enabled';
+                        statusStr = $.mage.__('enabled');
                         ioSnippetStatus = true;
                     } else {
                         toggled = 'disabled';
+                        statusStr = $.mage.__('disabled');
                         ioSnippetStatus = false;
                     }
 

--- a/view/adminhtml/web/js/maintenance.js
+++ b/view/adminhtml/web/js/maintenance.js
@@ -147,13 +147,15 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (superUsers === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
-                        successSuBtnMsg.text($.mage.__('Maintenance Mode successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successSuBtnMsg.text($.mage.__('Maintenance Mode successfully %1.').replace('%1', statusStr)).show();
                         $('.su_state_span').hide();
 
                         if (disabledOrEnabled === 'enabled') {

--- a/view/adminhtml/web/js/maintenance.js
+++ b/view/adminhtml/web/js/maintenance.js
@@ -153,7 +153,7 @@ define([
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
-                        successSuBtnMsg.text($.mage.__('Maintenance Mode successfully ' + disabledOrEnabled + '.')).show();
+                        successSuBtnMsg.text($.mage.__('Maintenance Mode successfully %1.').replace('%1', disabledOrEnabled)).show();
                         $('.su_state_span').hide();
 
                         if (disabledOrEnabled === 'enabled') {

--- a/view/adminhtml/web/js/modly.js
+++ b/view/adminhtml/web/js/modly.js
@@ -155,7 +155,7 @@ define([
                             if (response.status === true) {
                                 moduleModal.modal('closeModal');
                                 resetAllMessages();
-                                successAllModulesBtnMsg.text($.mage.__('The '+ moduleId +' module has been successfully uploaded to the Fastly service.')).show();
+                                successAllModulesBtnMsg.text($.mage.__('The %1 module has been successfully uploaded to the Fastly service.').replace('%1', moduleId)).show();
                                 module_field.closest('tr').find('.col-date').text(response.last_uploaded);
                             } else {
                                 resetAllMessages();

--- a/view/adminhtml/web/js/rate-limiting.js
+++ b/view/adminhtml/web/js/rate-limiting.js
@@ -268,14 +268,16 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (rateLimiting === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successRateLimitingBtnMsg.text($.mage.__('Path Protection successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successRateLimitingBtnMsg.text($.mage.__('Path Protection successfully %1.').replace('%1', statusStr)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             rateLimitingStateMsgSpan.find('#rate_limiting_state_disabled').hide();

--- a/view/adminhtml/web/js/rate-limiting.js
+++ b/view/adminhtml/web/js/rate-limiting.js
@@ -275,7 +275,7 @@ define([
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successRateLimitingBtnMsg.text($.mage.__('Path Protection successfully ' + disabledOrEnabled + '.')).show();
+                        successRateLimitingBtnMsg.text($.mage.__('Path Protection successfully %1.').replace('%1', disabledOrEnabled)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             rateLimitingStateMsgSpan.find('#rate_limiting_state_disabled').hide();

--- a/view/adminhtml/web/js/service-label.js
+++ b/view/adminhtml/web/js/service-label.js
@@ -9,8 +9,8 @@ define([
          * @type {*|jQuery|HTMLElement}
          */
         let msgWarning = $('.fastly-message-warning');
-        msgWarning.text($.mage.__('You are about to clone service **' + service_name + '** active version') + ' ' + active_version + '. '
-            + $.mage.__('We\'ll make changes to version ') + ' ' + next_version + '.');
+        msgWarning.text($.mage.__('You are about to clone service **%1** active version %2.').replace('%1', service_name).replace('%2', active_version) + ' '
+            + $.mage.__('We\'ll make changes to version %1.').replace('%1', next_version));
         msgWarning.show();
     }
 });

--- a/view/adminhtml/web/js/testconnection.js
+++ b/view/adminhtml/web/js/testconnection.js
@@ -27,7 +27,7 @@ define([
                     if (response.status === false) {
                         return testErrorBtnMsg.text($.mage.__('Please check your Service ID and API token and try again.')).show();
                     } else {
-                        return testSuccessBtnMsg.text($.mage.__('Connection to service name ' + response.service_name + ' has been successfully established. Please, save configuration and clear cache.')).show();
+                        return testSuccessBtnMsg.text($.mage.__('Connection to service name %1 has been successfully established. Please, save configuration and clear cache.').replace('%1', response.service_name)).show();
                     }
                 },
                 error: function () {

--- a/view/adminhtml/web/js/tls.js
+++ b/view/adminhtml/web/js/tls.js
@@ -154,13 +154,15 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (forceTls === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
-                        successTlsBtnMsg.text($.mage.__('Force TLS is successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successTlsBtnMsg.text($.mage.__('Force TLS is successfully %1.').replace('%1', statusStr)).show();
                         $('.request_tls_state_span').hide();
 
                         if (disabledOrEnabled === 'enabled') {

--- a/view/adminhtml/web/js/tls.js
+++ b/view/adminhtml/web/js/tls.js
@@ -160,7 +160,7 @@ define([
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
-                        successTlsBtnMsg.text($.mage.__('Force TLS is successfully ' + disabledOrEnabled + '.')).show();
+                        successTlsBtnMsg.text($.mage.__('Force TLS is successfully %1.').replace('%1', disabledOrEnabled)).show();
                         $('.request_tls_state_span').hide();
 
                         if (disabledOrEnabled === 'enabled') {

--- a/view/adminhtml/web/js/wafBypass.js
+++ b/view/adminhtml/web/js/wafBypass.js
@@ -181,14 +181,16 @@ define([
                     if (response.status === true) {
                         modal.modal('closeModal');
                         let disabledOrEnabled = 'disabled';
+                        let statusStr = $.mage.__('disabled');
 
                         if (wafBypass === false) {
                             disabledOrEnabled = 'enabled';
+                            statusStr = $.mage.__('enabled');
                         } else {
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successWafBypassBtnMsg.text($.mage.__('WAF Bypass is successfully %1.').replace('%1', disabledOrEnabled)).show();
+                        successWafBypassBtnMsg.text($.mage.__('WAF Bypass is successfully %1.').replace('%1', statusStr)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             wafBypassStateMsgSpan.find('#waf_bypass_state_disabled').hide();

--- a/view/adminhtml/web/js/wafBypass.js
+++ b/view/adminhtml/web/js/wafBypass.js
@@ -188,7 +188,7 @@ define([
                             disabledOrEnabled = 'disabled';
                         }
 
-                        successWafBypassBtnMsg.text($.mage.__('WAF Bypass is successfully ' + disabledOrEnabled + '.')).show();
+                        successWafBypassBtnMsg.text($.mage.__('WAF Bypass is successfully %1.').replace('%1', disabledOrEnabled)).show();
 
                         if (disabledOrEnabled === 'enabled') {
                             wafBypassStateMsgSpan.find('#waf_bypass_state_disabled').hide();


### PR DESCRIPTION
When I was proceeding translation for this extension, I found many JS messages where hard to translate. Using '+' operator for connecting text is easy, but this implementation way isn't better for translating these messages into other languages like Japanese. Then I replaced them into using 'replace' method and '%n' placeholder. As you know this message format is same as Magento core codes. Translators can move all placeholders into suitable place of the sentence.