### PR TITLE
feature/M095M01A-15 [MAGENTO 2] Edge modules with Grouped settings do…

### DIFF
--- a/view/adminhtml/web/js/modly.js
+++ b/view/adminhtml/web/js/modly.js
@@ -941,7 +941,10 @@ define([
                             question.find('.modly-group:first').find('.remove-group-button').closest('.field').hide();
                             $('.group-button').unbind('click').on('click', function () {
                                 question.find('.modly-group:last').clone().appendTo('.question');
-                                question.find('.modly-group:last').find('.modly-field').val('');
+                                question.find('.modly-group:last').find('.modly-field').each(function (i, e) {
+                                    let o = $(e).find('option:first')
+                                    $(e).val($(o).val());
+                                });
                                 question.find('.modly-group:last').find('.remove-group-button').closest('.field').show();
                                 $('.remove-group-button').unbind('click').on('click', function () {
                                     $(this).closest('.modly-group').remove();


### PR DESCRIPTION
…n't carry over default settings Best illustrated like this

- Add selection of first option when valid, for cloned groups