### PR TITLE
rate-limiting should handle REST APIs

### DIFF
--- a/Model/FrontControllerPlugin.php
+++ b/Model/FrontControllerPlugin.php
@@ -115,12 +115,12 @@ class FrontControllerPlugin
 
     /**
      * Check if request is limited
-     * @param FrontController $subject
+     * @param mixed $frontController
      * @param callable $proceed
      * @param mixed ...$args
      * @return \Magento\Framework\App\Response\Http|\Magento\Framework\App\ResponseInterface
      */
-    public function aroundDispatch(FrontController $subject, callable $proceed, ...$args) // @codingStandardsIgnoreLine - unused parameter
+    public function aroundDispatch($frontController, callable $proceed, ...$args) // @codingStandardsIgnoreLine - unused parameter
     {
         $isRateLimitingEnabled = $this->config->isRateLimitingEnabled();
         $isCrawlerProtectionEnabled = $this->config->isCrawlerProtectionEnabled();

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Webapi\Controller\Rest">
+        <plugin name="fastly_rate_limiter" type="Fastly\Cdn\Model\FrontControllerPlugin"/>
+    </type>
     <type name="Magento\Catalog\Model\Product">
         <plugin name="configurable_identity" type="Magento\ConfigurableProduct\Plugin\Model\Product" disabled="true"/>
     </type>


### PR DESCRIPTION
@vvuksan @MartinPeverelli 

I noticed that our rate limiting feature doesn't handle REST API calls (e.g., `/rest/V1/guest-carts/:cartId/payment-information`). This PR should fix that (tested locally), but can you please review this on your end as well? I don't have enough Magento code stack knowledge and I may be missing something. Thanks