### PR TITLE
Fix VCL tempalte replacement for querystring.regfilter()

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -512,9 +512,13 @@ class Api
             $adminPathTimeout = $this->config->getAdminPathTimeout();
             $ignoredUrlParameters = $this->config->getIgnoredUrlParameters();
 
-            $ignoredUrlParameterPieces = explode(",", $ignoredUrlParameters);
-            $filterIgnoredUrlParameterPieces = array_filter(array_map('trim', $ignoredUrlParameterPieces));
-            $queryParameters = implode('|', $filterIgnoredUrlParameterPieces);
+            if ($ignoredUrlParameters === "") {
+                $queryParameters = '&';
+            } else {
+                $ignoredUrlParameterPieces = explode(",", $ignoredUrlParameters);
+                $filterIgnoredUrlParameterPieces = array_filter(array_map('trim', $ignoredUrlParameterPieces));
+                $queryParameters = implode('|', $filterIgnoredUrlParameterPieces);
+            }
 
             $snippet['content'] = str_replace('####ADMIN_PATH####', $adminUrl, $snippet['content']);
             $snippet['content'] = str_replace('####ADMIN_PATH_TIMEOUT####', $adminPathTimeout, $snippet['content']);


### PR DESCRIPTION
If users do not want to strip any query parameters and decided to leave the UI field as blank (remove all default values), that will produce `querystring.regfilter(req.url, "^()");` which matches any query parameters and eventually strip all parameters. To remediate this, we set "&" in case if the field is blank so this doesn't match any query parameters as "&" is a delimiter of query strings.