### PR TITLE
Shorten cache tags for GraphQL requests

### DIFF
--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\App\Response\Http">
+        <plugin name="fastly_adjust_cache_tags" type="Fastly\Cdn\Model\ResponsePlugin" sortOrder="100"/>
+    </type>
+</config>


### PR DESCRIPTION
This PR fixes issue #384 

All tags are shortened before cleaning cache. But currently only "frontend" pages are tagged with shortened tags.
This PR adds shortening tags for GraphQL requests which make cache cleaning consistent with previously added tags.