### PR TITLE
Fix GeoIP JS Redirect URL

### DIFF
--- a/view/frontend/templates/geoip/redirect.phtml
+++ b/view/frontend/templates/geoip/redirect.phtml
@@ -27,5 +27,5 @@
  */
 ?>
 <script type="text/javascript">
-    document.location.href = "<?php /* @noEscape */ echo $block->getRedirectUrl() ?>;"
+    document.location.href = "<?php /* @noEscape */ echo $block->getRedirectUrl() ?>";
 </script>

--- a/view/frontend/templates/geoip/redirect.phtml
+++ b/view/frontend/templates/geoip/redirect.phtml
@@ -27,5 +27,5 @@
  */
 ?>
 <script type="text/javascript">
-    document.location.href = "<?php /* @noEscape */ echo $block->getRedirectUrl() ?>";
+    document.location.href = "<?= /* @noEscape */ $block->getRedirectUrl() ?>";
 </script>


### PR DESCRIPTION
Expected:
JS redirects user to https://example.com/stores/store/switch/?___from_store=old_store_view&___store=new_store_view

Actual:
JS redirects user to https://example.com/stores/store/switch/?___from_store=old_store_view&___store=new_store_view;, resulting in a 404