### PR TITLE
use available method to retrieve configuration

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1067,7 +1067,7 @@ class Config extends \Magento\PageCache\Model\Config
      */
     public function getGeoIpMappingForCountry($countryCode)
     {
-        if ($mapping = $this->_scopeConfig->getValue(self::XML_FASTLY_GEOIP_COUNTRY_MAPPING)) {
+        if ($mapping = $this->getGeoIpRedirectMapping()) {
             return $this->extractMapping($mapping, $countryCode);
         }
         return null;


### PR DESCRIPTION
there is currently unnecessarily duplicated code and we can reuse the method defined below:

https://github.com/fastly/fastly-magento2/blob/67917532e8a3f2ca330dec1f426763731afc2e92/Model/Config.php#L760-L768