### PR TITLE
feature/M095M01A-29 #23: [MAGENTO 2] Make sure we are not sending pur…

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -179,6 +179,11 @@ class Api
      */
     public function cleanBySurrogateKey($keys)
     {
+        $keys = array_filter($keys);
+        if (empty($keys)) {
+            return true;
+        }
+
         $type = 'clean by key on ';
         $uri = $this->_getApiServiceUri() . 'purge';
         $num = count($keys);


### PR DESCRIPTION
…ges for empty surrogate keys

- Use array_filter to remove any `falsy` elements for surrogate keys array before purge
- Return early if surrogate keys array is empty