### PR TITLE
feature/M095M01A-32  [MAGENTO 2] Including HTML as default value in e…

### DIFF
--- a/view/adminhtml/web/js/modly.js
+++ b/view/adminhtml/web/js/modly.js
@@ -588,7 +588,7 @@ define([
             textAreaInput.attr('name', property.name);
             textAreaInput.attr('id', property.name);
             textAreaInput.attr('required', 'required');
-            textAreaInput.append(fieldValue);
+            textAreaInput[0].innerHTML = fieldValue;
 
             selectInput.attr('name', property.name);
             selectInput.attr('id', property.name);


### PR DESCRIPTION
…dge modules breaks the UI We

- Replace use of .append() with .innerHTML for textareaInput form element in modly.js