### PR TITLE
Correct Field size for magento_vcl

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -165,7 +165,7 @@ class UpgradeSchema implements UpgradeSchemaInterface // @codingStandardsIgnoreL
             )->addColumn(
                 'manifest_vcl',
                 \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-                \Magento\Framework\DB\Ddl\Table::DEFAULT_TEXT_SIZE,
+                \Magento\Framework\DB\Ddl\Table::MAX_TEXT_SIZE,
                 ['nullable' => false],
                 'Manifest VCL'
             )->addColumn(


### PR DESCRIPTION
The current file creates a table where the field size truncates to 65,535 bytes because it creates a "text" field. Changing this results in the field being created as a longtext field instead.