### PR TITLE
feature/M095M01A-36 [MAGENTO 2] Resolve empty cache problem with read…

### DIFF
--- a/Model/FrontControllerPlugin.php
+++ b/Model/FrontControllerPlugin.php
@@ -333,8 +333,8 @@ class FrontControllerPlugin
         $tag = self::FASTLY_CACHE_MAINTENANCE_IP_FILE_TAG;
         $data = json_decode($this->cache->load($tag));
         if (empty($data)) {
+            $data = [];
             $flagDir = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
-
             if ($flagDir->isExist('.maintenance.ip')) {
                 $temp = $flagDir->readFile('.maintenance.ip');
                 $data = explode(',', trim($temp));


### PR DESCRIPTION
…MaintenanceIp

- Add default iterable $data definition when maintenance ip cache is empty