### PR TITLE
Update docs links to Fastly docs

### DIFF
--- a/Documentation/CONFIGURATION.md
+++ b/Documentation/CONFIGURATION.md
@@ -15,14 +15,14 @@ to Fastly's CDN services.
 To proceed with configuration you will need to have
 [signed up for Fastly's service](https://www.fastly.com/signup). You will need
 the API token (https://manage.fastly.com/account/personal/tokens). Details of how to find these
-are kept in [Fastly's documentation](https://docs.fastly.com/guides/account-management-and-security/finding-and-managing-your-account-info).
+are kept in [Fastly's documentation](https://docs.fastly.com/en/guides/finding-and-managing-your-account-info).
 
 ## Configure the Fastly Service
 
 To start configuring the Fastly service for use with Magento ensure that you
 have [signed up](https://www.fastly.com/signup) for the service. Once you have
 confirmed the account and logged in the Fastly application will take you to a
-wizard to configure your first service. This is further documented on [Fastly's documentation](https://docs.fastly.com/guides/basic-setup/sign-up-and-create-your-first-service).
+wizard to configure your first service. This is further documented on [Fastly's documentation](https://docs.fastly.com/en/guides/sign-up-and-create-your-first-service).
 
 ## Configure the Module
 

--- a/Documentation/Guides/ACL.md
+++ b/Documentation/Guides/ACL.md
@@ -1,7 +1,7 @@
 # ACL (Access Control Lists)
 
 This guide will show how to add a Fastly ACL to your Fastly configuration. You can find more
-details on what ACLs are [here https://docs.fastly.com/guides/access-control-lists/about-edge-acls]
+details on what ACLs are [here](https://docs.fastly.com/en/guides/about-acls)
 
 To add an ACL, go to:
 ```

--- a/Documentation/Guides/CUSTOM-VCL-SNIPPETS.md
+++ b/Documentation/Guides/CUSTOM-VCL-SNIPPETS.md
@@ -55,7 +55,7 @@ content and upload VCL.
 # Automated custom VCL snippets deployment
 
 Please add any
-[VCL snippets](https://docs.fastly.com/guides/vcl-snippets/using-regular-vcl-snippets) 
+[VCL snippets](https://docs.fastly.com/en/guides/using-regular-vcl-snippets) 
 to `$MAGENTO_HOME/var/vcl_snippets_custom`
 that should be uploaded any time you click upload custom VCL in the Magento admin.
 

--- a/Documentation/Guides/Edge-Modules/EDGE-MODULE-OTHER-CMS-INTEGRATION.md
+++ b/Documentation/Guides/Edge-Modules/EDGE-MODULE-OTHER-CMS-INTEGRATION.md
@@ -51,7 +51,7 @@ adding a backend proceed to configuration.
 
 *Please note* you should specify a shield location for your backend and it should be close to your origin e.g.
 if your origin is in Netherlands pick our Amsterdam shield etc. Shield will greatly decrease the number of
-requests hitting your origin and is required for Image Optimization. [Read more about origin shielding](https://docs.fastly.com/guides/performance-tuning/shielding). 
+requests hitting your origin and is required for Image Optimization. [Read more about origin shielding](https://docs.fastly.com/en/guides/shielding). 
 
 ## Edge Module Configuration
 

--- a/Documentation/Guides/FORCE-TLS.md
+++ b/Documentation/Guides/FORCE-TLS.md
@@ -1,7 +1,7 @@
 # Force TLS guide
 
 This guide will show how to setup Secure base URL in Magento and turn on Force TLS option. 
-For this, you will need to have a TLS certificate. You can read [here](https://docs.fastly.com/guides/securing-communications/)
+For this, you will need to have a TLS certificate. You can read [here](https://docs.fastly.com/en/guides/security#_tls)
 on how to order a TLS certificate through Fastly and then set it up.
  
 Once your certificate has been deployed on Fastly go to:

--- a/Documentation/Guides/IMAGE-OPTIMIZATION.md
+++ b/Documentation/Guides/IMAGE-OPTIMIZATION.md
@@ -114,7 +114,7 @@ you can set this option to no.
 
 ## Set canvas parameter on images
 
-This feature is on by default when you enable deep image optimization. It adds canvas argument to the image optimization with the aspect ratio of the image. You can read more about this feature in Fastly [image optimization docs](https://docs.fastly.com/api/imageopto/canvas). Set to no to exclude.
+This feature is on by default when you enable deep image optimization. It adds canvas argument to the image optimization with the aspect ratio of the image. You can read more about this feature in Fastly [image optimization docs](https://docs.fastly.com/en/image-optimization-api/canvas). Set to no to exclude.
 
 ## Adaptive pixel ratios
 

--- a/Documentation/TLS.md
+++ b/Documentation/TLS.md
@@ -1,7 +1,7 @@
 # TLS Deployment
 
 This document describes the options for implementing TLS. Fastly's TLS options
-are detailed in their [documentation](https://docs.fastly.com/guides/securing-communications/ordering-a-paid-tls-option)
+are detailed in their [documentation](https://docs.fastly.com/products/tls-service-options).
 
 ## Contents
 
@@ -40,7 +40,7 @@ the way as traffic from the CDN to the Magento server is not encrypted.
 
 To terminate TLS at Fastly you will need to choose one of the TLS options that
 Fastly provides. For testing it is possible to use
-[Fastly's Free Shared Domain](https://docs.fastly.com/guides/securing-communications/setting-up-free-tls)
+[Fastly's Free Shared Domain](https://docs.fastly.com/en/guides/setting-up-free-tls)
 option. If doing so, make sure to set the base-urls in Magento to the same name.
 
 In Fastly's Configure page set the origin port to 80 (or the listening port of
@@ -78,7 +78,7 @@ Once the Magento server is properly configured, log in to the Fastly
 application and configure a second origin with the same address. Make sure to
 choose port 443, or set the TLS option to use TLS for this connection. Further
 details of how to configure the options are in
-[Fastly's documentation](https://docs.fastly.com/guides/securing-communications/connecting-to-origins-over-tls).
+[Fastly's documentation](https://docs.fastly.com/en/guides/connecting-to-origins).
 
 Add a condition to the server with the following details:
 
@@ -115,4 +115,4 @@ setting the environment variable 'Https' to 'On' as described above.
 
 As a failsafe for any URLs which may not have the correct protocol prefixed to
 them add a rule to 'Force TLS' in Fastly. The rule is described in
-[Fastly's Documentation](https://docs.fastly.com/guides/securing-communications/allowing-only-tls-connections-to-your-site).
+[Fastly's Documentation](https://docs.fastly.com/en/guides/forcing-a-tls-redirect).


### PR DESCRIPTION
This commit updates some documentation links to the Fastly https://docs.fastly.com/ site as some of the pages have since moved around.