### PR TITLE
MC-38266: [Fastly] Unexpected behavior of a "Fastly" tab on the Dashboard page

### DIFF
--- a/view/adminhtml/web/js/historicstats.js
+++ b/view/adminhtml/web/js/historicstats.js
@@ -2,7 +2,8 @@ define([
     'jquery',
     'mage/translate',
     'https://www.gstatic.com/charts/loader.js',
-    'moment'
+    'moment',
+    'mage/calendar'
 ], function ($, t, g, moment) {
     "use strict";
     return function (config) {


### PR DESCRIPTION
This PR fixes issue caused by [commit](https://github.com/magento/magento2/pull/27860/commits/4c21e460d180de2d76810cddd6a53d256113656c) where Magento/Ui/view/base/web/js/lib/knockout/bindings/datepicker.js no longer uses 'mage/calendar' dependency by default and as result we get JavaScript error and wrong behaviour when opening Fastly tab on Dashboard page.  It's caused issue in Fastly extension since it's incorrectly using dependency by using the method of the library that wasn't explicitly loaded on the page.