### PR TITLE
[Bug] honor original request method even if it's called from lookup

### DIFF
--- a/etc/vcl_snippets_rate_limiting/miss.vcl
+++ b/etc/vcl_snippets_rate_limiting/miss.vcl
@@ -1,0 +1,3 @@
+if (req.http.Rate-Limit) {
+  set bereq.method = req.http.X-Orig-Method;
+}

--- a/etc/vcl_snippets_rate_limiting/recv.vcl
+++ b/etc/vcl_snippets_rate_limiting/recv.vcl
@@ -1,4 +1,5 @@
 if (####RATE_LIMITED_PATHS####) {
-   set req.http.Rate-Limit = "1";
-   set req.hash_ignore_busy = true;
+  set req.http.Rate-Limit = "1";
+  set req.http.X-Orig-Method = req.method;
+  set req.hash_ignore_busy = true;
 }


### PR DESCRIPTION
Rate-limiting module creates a Request Settings that is turned into the below VCL code:

```c
# Request Condition: magentomodule_rate_limiting Prio: 150
if( req.http.Rate-Limit ) {
  return(lookup);
}
```

This would break Magento site functionalities since Fastly Varnish has surprising behavior where any request method except POST is being overwritten to GET if `return(lookup)` is called for the request.

So once this rate-limiting module is enabled, request methods such as DELETE, PUT, etc no longer work as expected and the origin server receives transformed GET requests instead.

To work around this, we stash the original request method in recv and restore it in miss if rate-limit module is enabled for the request. This would cause all request methods that are not defined as cacheable in [RFC ](https://tools.ietf.org/html/rfc7231#section-4.2.3) to be cached, which is bad. But since we also have this snippet in fetch:

https://github.com/fastly/fastly-magento2/blob/master/etc/vcl_snippets_rate_limiting/fetch.vcl#L1-L11

only 429 response is cached and all other status codes are forced to be PASS. So we should be fine with this change.