### PR TITLE
don't discard request body

### DIFF
--- a/etc/vcl_snippets_rate_limiting/recv.vcl
+++ b/etc/vcl_snippets_rate_limiting/recv.vcl
@@ -2,4 +2,7 @@ if (####RATE_LIMITED_PATHS####) {
   set req.http.Rate-Limit = "1";
   set req.http.X-Orig-Method = req.method;
   set req.hash_ignore_busy = true;
+  if (req.method !~ "^(GET|POST)$") {
+    set req.method = "POST";
+  }
 }


### PR DESCRIPTION
Continuing the previous PR: https://github.com/fastly/fastly-magento2/pull/434

Fastly Varnish would discard the request body when `return(lookup)` is called except `POST` method.
We can fake the request method to POST to save the request body then later we restore the original request method in `vcl_miss`.

current: https://fiddle.fastlydemo.net/fiddle/c9e8659c
fix: https://fiddle.fastlydemo.net/fiddle/ae94b715
\* see the `data` field of the response body
