### PR TITLE
Update shielding POP info (Singapore)

### DIFF
--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -400,11 +400,17 @@
                             <option value="msp-mn-us">
                             Minneapolis (MSP)
                             </option>
+                            <option value="yul-montreal-ca">
+                            Montreal (YUL)
+                            </option>
                             <option value="lga-ny-us">
                             New York City (LGA)
                             </option>
                             <option value="pao-ca-us">
                             Palo Alto (PAO) - Recommended for AWS us-west-1
+                            </option>
+                            <option value="pdx-or-us">
+                            Portland (PDX)
                             </option>
                             <option value="sjc-ca-us">
                             San Jose (SJC)
@@ -448,7 +454,7 @@
                             Perth (PER)
                             </option>
                             <option value="qpg-singapore-sg">
-                            Singapore (SIN) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
+                            Singapore (QPG) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
                             </option>
                             <option value="sydney-au">
                             Sydney (SYD) - Recommended for AWS ap-southeast-2, GCP australia-southeast1
@@ -476,6 +482,9 @@
                         <optgroup label="Brazil">
                             <option value="gig-riodejaneiro-br">
                             Rio de Janeiro (GIG) - Recommended for AWS sa-east-1
+                            </option>
+                            <option value="cgh-saopaulo-br">
+                            Sao Paulo (CGH)
                             </option>
                             <option value="gru-br-sa">
                             Sao Paulo (GRU) - Recommended for AWS southamerica-east1
@@ -740,11 +749,17 @@
                             <option value="msp-mn-us">
                             Minneapolis (MSP)
                             </option>
+                            <option value="yul-montreal-ca">
+                            Montreal (YUL)
+                            </option>
                             <option value="lga-ny-us">
                             New York City (LGA)
                             </option>
                             <option value="pao-ca-us">
                             Palo Alto (PAO) - Recommended for AWS us-west-1
+                            </option>
+                            <option value="pdx-or-us">
+                            Portland (PDX)
                             </option>
                             <option value="sjc-ca-us">
                             San Jose (SJC)
@@ -788,7 +803,7 @@
                             Perth (PER)
                             </option>
                             <option value="qpg-singapore-sg">
-                            Singapore (SIN) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
+                            Singapore (QPG) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
                             </option>
                             <option value="sydney-au">
                             Sydney (SYD) - Recommended for AWS ap-southeast-2, GCP australia-southeast1
@@ -816,6 +831,9 @@
                         <optgroup label="Brazil">
                             <option value="gig-riodejaneiro-br">
                             Rio de Janeiro (GIG) - Recommended for AWS sa-east-1
+                            </option>
+                            <option value="cgh-saopaulo-br">
+                            Sao Paulo (CGH)
                             </option>
                             <option value="gru-br-sa">
                             Sao Paulo (GRU) - Recommended for AWS southamerica-east1

--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -447,7 +447,7 @@
                             <option value="perth-au">
                             Perth (PER)
                             </option>
-                            <option value="singapore-sg">
+                            <option value="qpg-singapore-sg">
                             Singapore (SIN) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
                             </option>
                             <option value="sydney-au">
@@ -787,7 +787,7 @@
                             <option value="perth-au">
                             Perth (PER)
                             </option>
-                            <option value="singapore-sg">
+                            <option value="qpg-singapore-sg">
                             Singapore (SIN) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
                             </option>
                             <option value="sydney-au">


### PR DESCRIPTION
Changed the PoP ID for Singapore from **singapore-sg** to **qpg-singapore-sg**.