### PR TITLE
use local file for shielding list

### DIFF
--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -270,6 +270,36 @@
     </form>
 </script>
 
+<?php
+    $shieldingList = json_decode(file_get_contents(__DIR__ . '/shielding.json'));
+    $arrayShield = array();
+
+    foreach ($shieldingList as $pop) {
+        if (property_exists($pop, 'shield')) {
+            switch ($pop->group) {
+                case 'Europe';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+                case 'United States';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+                case 'Asia/Pacific';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+                case 'South America';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+                case 'South Africa';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+                case 'Brazil';
+                    $arrayShield[$pop->group][] = (object)['name'=>$pop->name, 'code'=>$pop->code, 'shield'=>$pop->shield];
+                    break;
+            }
+        }
+    }
+?>
+
 <!-- Backend configuration overlay template -->
 <script type="text/x-magento-template" id="fastly-backend-template">
     <div class="messages">
@@ -298,198 +328,16 @@
                             (none)
                             </option>
                         </optgroup>
-                        <optgroup label="Europe">
-                            <option value="amsterdam-nl">
-                            Amsterdam (AMS) - Recommended for GCP europe-west4
-                            </option>
-                            <option value="cph-copenhagen-dk">
-                            Copenhagen (CPH)
-                            </option>
-                            <option value="dub-dublin-ie">
-                            Dublin (DUB) - Recommended for AWS eu-west-1
-                            </option>
-                            <option value="frankfurt-de">
-                            Frankfurt (FRA) - Recommended for AWS eu-central-1, GCP europe-west1/3
-                            </option>
-                            <option value="hhn-frankfurt-de">
-                            Frankfurt - Interxion (HHN)
-                            </option>
-                            <option value="hel-helsinki-fi">
-                            Helsinki (HEL) - Recommended for GCP europe-north1
-                            </option>
-                            <option value="london_city-uk">
-                            London (LCY)
-                            </option>
-                            <option value="lon-london-uk">
-                            London (LON)
-                            </option>
-                            <option value="london-uk">
-                            London (LHR) - Recommended for AWS eu-west-2, GCP europe-west2
-                            </option>
-                            <option value="mad-madrid-es">
-                            Madrid (MAD)
-                            </option>
-                            <option value="man-manchester-uk">
-                            Manchester (MAN)
-                            </option>
-                            <option value="mrs-marseille-fr">
-                            Marseille (MRS)
-                            </option>
-                            <option value="mxp-milan-it">
-                            Milan (MXP) - Recommended for AWS eu-south-1/me-south-1, GCP europe-west6
-                            </option>
-                            <option value="osl-oslo-no">
-                            Oslo (OSL)
-                            </option>
-                            <option value="cdg-par-fr">
-                            Paris (CDG) - Recommended for AWS eu-west-3
-                            </option>
-                            <option value="stockholm-bma">
-                            Stockholm (BMA) - Recommended for AWS eu-north-1
-                            </option>
-                            <option value="vie-vienna-at">
-                            Vienna (VIE)
-                            </option>
-                        </optgroup>
-                        <optgroup label="United States">
-                            <option value="bwi-va-us">
-                            Ashburn (BWI)
-                            </option>
-                            <option value="dca-dc-us">
-                            Ashburn (DCA) - Recommended for AWS us-east-1, GCP us-east1/4
-                            </option>
-                            <option value="fty-ga-us">
-                            Atlanta (FTY)
-                            </option>
-                            <option value="bos-ma-us">
-                            Boston (BOS)
-                            </option>
-                            <option value="chi-il-us">
-                            Chicago (CHI)
-                            </option>
-                            <option value="mdw-il-us">
-                            Chicago (MDW) - Recommended for AWS us-east-2, GCP us-central1
-                            </option>
-                            <option value="pwk-il-us">
-                            Chicago (PWK)
-                            </option>
-                            <option value="dallas-tx-us">
-                            Dallas (DFW)
-                            </option>
-                            <option value="dal-tx-us">
-                            Dallas (DAL)
-                            </option>
-                            <option value="den-co-us">
-                            Denver (DEN)
-                            </option>
-                            <option value="iah-tx-us">
-                            Houston (IAH)
-                            </option>
-                            <option value="jax-fl-us">
-                            Jacksonville (JAX)
-                            </option>
-                            <option value="lgb-ca-us">
-                            Los Angeles (Metro) (LGB)
-                            </option>
-                            <option value="bur-ca-us">
-                            Los Angeles (BUR) - Recommended for GCP us-west2/3/4
-                            </option>
-                            <option value="miami-fl-us">
-                            Miami (MIA)
-                            </option>
-                            <option value="msp-mn-us">
-                            Minneapolis (MSP)
-                            </option>
-                            <option value="yul-montreal-ca">
-                            Montreal (YUL)
-                            </option>
-                            <option value="lga-ny-us">
-                            New York City (LGA)
-                            </option>
-                            <option value="pao-ca-us">
-                            Palo Alto (PAO) - Recommended for AWS us-west-1
-                            </option>
-                            <option value="pdx-or-us">
-                            Portland (PDX)
-                            </option>
-                            <option value="sjc-ca-us">
-                            San Jose (SJC)
-                            </option>
-                            <option value="sea-wa-us">
-                            Seattle (SEA) - Recommended for AWS us-west-2, GCP us-west1
-                            </option>
-                            <option value="yyz-on-ca">
-                            Toronto (YYZ) - Recommended for AWS ca-central-1
-                            </option>
-                        </optgroup>
-                        <optgroup label="Asia/Pacific">
-                            <option value="auckland-akl">
-                            Auckland (AKL)
-                            </option>
-                            <option value="brisbane-au">
-                            Brisbane (BNE)
-                            </option>
-                            <option value="maa-chennai-in">
-                            Chennai (MAA)
-                            </option>
-                            <option value="del-delhi-in">
-                            Delhi (DEL)
-                            </option>
-                            <option value="fjr-ae">
-                            Fujairah Al Mahta (FJR)
-                            </option>
-                            <option value="hongkong-hk">
-                            Hong Kong (HKG) - Recommended for AWS ap-east-1/cn-north-1/cn-northwest-1, GCP asia-east1/2
-                            </option>
-                            <option value="melbourne-au">
-                            Melbourne (MEL)
-                            </option>
-                            <option value="bom-mumbai-in">
-                            Mumbai (BOM) - Recommended for AWS ap-south-1
-                            </option>
-                            <option value="osaka-jp">
-                            Osaka (ITM) - Recommended for AWS ap-northeast-2/3
-                            </option>
-                            <option value="perth-au">
-                            Perth (PER)
-                            </option>
-                            <option value="qpg-singapore-sg">
-                            Singapore (QPG) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
-                            </option>
-                            <option value="sydney-au">
-                            Sydney (SYD) - Recommended for AWS ap-southeast-2, GCP australia-southeast1
-                            </option>
-                            <option value="tyo-tokyo-jp">
-                            Tokyo (TYO) - Recommended for AWS ap-northeast-1
-                            </option>
-                            <option value="hnd-tokyo-jp">
-                            Tokyo (HND) - Recommended for GCP asia-northeast1/2/3
-                            </option>
-                        </optgroup>
-                        <optgroup label="South America">
-                            <option value="bog-bogota-co">
-                            Bogota (BOG)
-                            </option>
-                        </optgroup>
-                        <optgroup label="South Africa">
-                            <option value="cpt-capetown-za">
-                            Cape Town (CPT) - Recommended for AWS af-south-1
-                            </option>
-                            <option value="jnb-johannesburg-za">
-                            Johannesburg (JNB)
-                            </option>
-                        </optgroup>
-                        <optgroup label="Brazil">
-                            <option value="gig-riodejaneiro-br">
-                            Rio de Janeiro (GIG) - Recommended for AWS sa-east-1
-                            </option>
-                            <option value="cgh-saopaulo-br">
-                            Sao Paulo (CGH)
-                            </option>
-                            <option value="gru-br-sa">
-                            Sao Paulo (GRU) - Recommended for AWS southamerica-east1
-                            </option>
-                        </optgroup>
+
+                        <?php foreach ($arrayShield as $group=>$pops) { ?>
+                            <optgroup label="<?php echo $group; ?>">
+                            <?php foreach ($pops as $pop) { ?>
+                                <option value="<?php echo $pop->shield; ?>">
+                                <?php echo $pop->name; ?> (<?php echo $pop->code; ?>)
+                                </option>
+                            </optgroup>
+                            <?php } ?>
+                        <?php } ?>
                     </select>
                     <div class="admin__field-note">
                         The shield POP designated to reduce inbound load on this origin by serving the cached data to
@@ -647,198 +495,16 @@
                             (none)
                             </option>
                         </optgroup>
-                        <optgroup label="Europe">
-                            <option value="amsterdam-nl">
-                            Amsterdam (AMS) - Recommended for GCP europe-west4
-                            </option>
-                            <option value="cph-copenhagen-dk">
-                            Copenhagen (CPH)
-                            </option>
-                            <option value="dub-dublin-ie">
-                            Dublin (DUB) - Recommended for AWS eu-west-1
-                            </option>
-                            <option value="frankfurt-de">
-                            Frankfurt (FRA) - Recommended for AWS eu-central-1, GCP europe-west1/3
-                            </option>
-                            <option value="hhn-frankfurt-de">
-                            Frankfurt - Interxion (HHN)
-                            </option>
-                            <option value="hel-helsinki-fi">
-                            Helsinki (HEL) - Recommended for GCP europe-north1
-                            </option>
-                            <option value="london_city-uk">
-                            London (LCY)
-                            </option>
-                            <option value="lon-london-uk">
-                            London (LON)
-                            </option>
-                            <option value="london-uk">
-                            London (LHR) - Recommended for AWS eu-west-2, GCP europe-west2
-                            </option>
-                            <option value="mad-madrid-es">
-                            Madrid (MAD)
-                            </option>
-                            <option value="man-manchester-uk">
-                            Manchester (MAN)
-                            </option>
-                            <option value="mrs-marseille-fr">
-                            Marseille (MRS)
-                            </option>
-                            <option value="mxp-milan-it">
-                            Milan (MXP) - Recommended for AWS eu-south-1/me-south-1, GCP europe-west6
-                            </option>
-                            <option value="osl-oslo-no">
-                            Oslo (OSL)
-                            </option>
-                            <option value="cdg-par-fr">
-                            Paris (CDG) - Recommended for AWS eu-west-3
-                            </option>
-                            <option value="stockholm-bma">
-                            Stockholm (BMA) - Recommended for AWS eu-north-1
-                            </option>
-                            <option value="vie-vienna-at">
-                            Vienna (VIE)
-                            </option>
-                        </optgroup>
-                        <optgroup label="United States">
-                            <option value="bwi-va-us">
-                            Ashburn (BWI)
-                            </option>
-                            <option value="dca-dc-us">
-                            Ashburn (DCA) - Recommended for AWS us-east-1, GCP us-east1/4
-                            </option>
-                            <option value="fty-ga-us">
-                            Atlanta (FTY)
-                            </option>
-                            <option value="bos-ma-us">
-                            Boston (BOS)
-                            </option>
-                            <option value="chi-il-us">
-                            Chicago (CHI)
-                            </option>
-                            <option value="mdw-il-us">
-                            Chicago (MDW) - Recommended for AWS us-east-2, GCP us-central1
-                            </option>
-                            <option value="pwk-il-us">
-                            Chicago (PWK)
-                            </option>
-                            <option value="dallas-tx-us">
-                            Dallas (DFW)
-                            </option>
-                            <option value="dal-tx-us">
-                            Dallas (DAL)
-                            </option>
-                            <option value="den-co-us">
-                            Denver (DEN)
-                            </option>
-                            <option value="iah-tx-us">
-                            Houston (IAH)
-                            </option>
-                            <option value="jax-fl-us">
-                            Jacksonville (JAX)
-                            </option>
-                            <option value="lgb-ca-us">
-                            Los Angeles (Metro) (LGB)
-                            </option>
-                            <option value="bur-ca-us">
-                            Los Angeles (BUR) - Recommended for GCP us-west2/3/4
-                            </option>
-                            <option value="miami-fl-us">
-                            Miami (MIA)
-                            </option>
-                            <option value="msp-mn-us">
-                            Minneapolis (MSP)
-                            </option>
-                            <option value="yul-montreal-ca">
-                            Montreal (YUL)
-                            </option>
-                            <option value="lga-ny-us">
-                            New York City (LGA)
-                            </option>
-                            <option value="pao-ca-us">
-                            Palo Alto (PAO) - Recommended for AWS us-west-1
-                            </option>
-                            <option value="pdx-or-us">
-                            Portland (PDX)
-                            </option>
-                            <option value="sjc-ca-us">
-                            San Jose (SJC)
-                            </option>
-                            <option value="sea-wa-us">
-                            Seattle (SEA) - Recommended for AWS us-west-2, GCP us-west1
-                            </option>
-                            <option value="yyz-on-ca">
-                            Toronto (YYZ) - Recommended for AWS ca-central-1
-                            </option>
-                        </optgroup>
-                        <optgroup label="Asia/Pacific">
-                            <option value="auckland-akl">
-                            Auckland (AKL)
-                            </option>
-                            <option value="brisbane-au">
-                            Brisbane (BNE)
-                            </option>
-                            <option value="maa-chennai-in">
-                            Chennai (MAA)
-                            </option>
-                            <option value="del-delhi-in">
-                            Delhi (DEL)
-                            </option>
-                            <option value="fjr-ae">
-                            Fujairah Al Mahta (FJR)
-                            </option>
-                            <option value="hongkong-hk">
-                            Hong Kong (HKG) - Recommended for AWS ap-east-1/cn-north-1/cn-northwest-1, GCP asia-east1/2
-                            </option>
-                            <option value="melbourne-au">
-                            Melbourne (MEL)
-                            </option>
-                            <option value="bom-mumbai-in">
-                            Mumbai (BOM) - Recommended for AWS ap-south-1
-                            </option>
-                            <option value="osaka-jp">
-                            Osaka (ITM) - Recommended for AWS ap-northeast-2/3
-                            </option>
-                            <option value="perth-au">
-                            Perth (PER)
-                            </option>
-                            <option value="qpg-singapore-sg">
-                            Singapore (QPG) - Recommended for AWS ap-southeast-1, GCP asia-south1/asia-southeast1/2
-                            </option>
-                            <option value="sydney-au">
-                            Sydney (SYD) - Recommended for AWS ap-southeast-2, GCP australia-southeast1
-                            </option>
-                            <option value="tyo-tokyo-jp">
-                            Tokyo (TYO) - Recommended for AWS ap-northeast-1
-                            </option>
-                            <option value="hnd-tokyo-jp">
-                            Tokyo (HND) - Recommended for GCP asia-northeast1/2/3
-                            </option>
-                        </optgroup>
-                        <optgroup label="South America">
-                            <option value="bog-bogota-co">
-                            Bogota (BOG)
-                            </option>
-                        </optgroup>
-                        <optgroup label="South Africa">
-                            <option value="cpt-capetown-za">
-                            Cape Town (CPT) - Recommended for AWS af-south-1
-                            </option>
-                            <option value="jnb-johannesburg-za">
-                            Johannesburg (JNB)
-                            </option>
-                        </optgroup>
-                        <optgroup label="Brazil">
-                            <option value="gig-riodejaneiro-br">
-                            Rio de Janeiro (GIG) - Recommended for AWS sa-east-1
-                            </option>
-                            <option value="cgh-saopaulo-br">
-                            Sao Paulo (CGH)
-                            </option>
-                            <option value="gru-br-sa">
-                            Sao Paulo (GRU) - Recommended for AWS southamerica-east1
-                            </option>
-                        </optgroup>
+                        
+                        <?php foreach ($arrayShield as $group=>$pops) { ?>
+                            <optgroup label="<?php echo $group; ?>">
+                            <?php foreach ($pops as $pop) { ?>
+                                <option value="<?php echo $pop->shield; ?>">
+                                <?php echo $pop->name; ?> (<?php echo $pop->code; ?>)
+                                </option>
+                            </optgroup>
+                            <?php } ?>
+                        <?php } ?>
                     </select>
                     <div class="admin__field-note">
                         The shield POP designated to reduce inbound load on this origin by serving the cached data to

--- a/view/adminhtml/templates/system/config/dialogs.phtml
+++ b/view/adminhtml/templates/system/config/dialogs.phtml
@@ -342,7 +342,7 @@
                     <div class="admin__field-note">
                         The shield POP designated to reduce inbound load on this origin by serving the cached data to
                         the rest of the network.
-                        <a href="https://docs.fastly.com/guides/performance-tuning/shielding"
+                        <a href="https://developer.fastly.com/learning/concepts/shielding/"
                            target="_blank">Click for more details.</a>
                     </div>
                 </div>
@@ -509,7 +509,7 @@
                     <div class="admin__field-note">
                         The shield POP designated to reduce inbound load on this origin by serving the cached data to
                         the rest of the network.
-                        <a href="https://docs.fastly.com/guides/performance-tuning/shielding"
+                        <a href="https://developer.fastly.com/learning/concepts/shielding/"
                            target="_blank">Click for more details.</a>
                     </div>
                 </div>

--- a/view/adminhtml/templates/system/config/shielding.json
+++ b/view/adminhtml/templates/system/config/shielding.json
@@ -1,0 +1,942 @@
+[
+    {
+        "code": "AMS",
+        "name": "Amsterdam",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 52.308613,
+            "longitude": 4.763889
+        },
+        "shield": "amsterdam-nl"
+    },
+    {
+        "code": "IAD",
+        "name": "Ashburn",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 38.944533,
+            "longitude": -77.455811
+        }
+    },
+    {
+        "code": "WDC",
+        "name": "Ashburn",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 39.022,
+            "longitude": -77.451
+        }
+    },
+    {
+        "code": "BWI",
+        "name": "Ashburn - BWI",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 38.944533,
+            "longitude": -77.455811
+        },
+        "shield": "bwi-va-us"
+    },
+    {
+        "code": "DCA",
+        "name": "Ashburn - DCA",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 38.851242,
+            "longitude": -77.040232
+        },
+        "shield": "dca-dc-us"
+    },
+    {
+        "code": "FTY",
+        "name": "Atlanta - FTY",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 33.636719,
+            "longitude": -84.428067
+        },
+        "shield": "fty-ga-us"
+    },
+    {
+        "code": "PDK",
+        "name": "Atlanta - PDK",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 33.876819,
+            "longitude": -84.302921
+        }
+    },
+    {
+        "code": "AKL",
+        "name": "Auckland",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -37.008056,
+            "longitude": 174.791667
+        },
+        "shield": "auckland-akl"
+    },
+    {
+        "code": "BOG",
+        "name": "Bogota",
+        "group": "South America",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 4.711,
+            "longitude": -74.072
+        },
+        "shield": "bog-bogota-co"
+    },
+    {
+        "code": "BOS",
+        "name": "Boston",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 42.364347,
+            "longitude": -71.005181
+        },
+        "shield": "bos-ma-us"
+    },
+    {
+        "code": "BNE",
+        "name": "Brisbane",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -27.384167,
+            "longitude": 153.1175
+        },
+        "shield": "brisbane-au"
+    },
+    {
+        "code": "EZE",
+        "name": "Buenos Aires",
+        "group": "South America",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -34.815,
+            "longitude": -58.5348
+        }
+    },
+    {
+        "code": "CPT",
+        "name": "Cape Town",
+        "group": "South Africa",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -33.97,
+            "longitude": 18.464
+        },
+        "shield": "cpt-capetown-za"
+    },
+    {
+        "code": "MAA",
+        "name": "Chennai",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 12.9941,
+            "longitude": 80.1709
+        },
+        "shield": "maa-chennai-in"
+    },
+    {
+        "code": "ORD",
+        "name": "Chicago",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 41.978603,
+            "longitude": -87.904842
+        }
+    },
+    {
+        "code": "CHI",
+        "name": "Chicago - CHI",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 41.9742,
+            "longitude": -87.9073
+        },
+        "shield": "chi-il-us"
+    },
+    {
+        "code": "MDW",
+        "name": "Chicago - MDW",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 41.7867799,
+            "longitude": -87.7543771
+        },
+        "shield": "mdw-il-us"
+    },
+    {
+        "code": "PWK",
+        "name": "Chicago - PWK",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 42.1171,
+            "longitude": -87.9011
+        },
+        "shield": "pwk-il-us"
+    },
+    {
+        "code": "CMH",
+        "name": "Columbus",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.116,
+            "longitude": -83.002
+        }
+    },
+    {
+        "code": "LCK",
+        "name": "Columbus",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.116,
+            "longitude": -83.002
+        }
+    },
+    {
+        "code": "CPH",
+        "name": "Copenhagen",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 55.728081,
+            "longitude": 12.37752
+        },
+        "shield": "cph-copenhagen-dk"
+    },
+    {
+        "code": "CWB",
+        "name": "Curitiba",
+        "group": "Brazil",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -25.4809,
+            "longitude": -49.3044
+        }
+    },
+    {
+        "code": "DFW",
+        "name": "Dallas",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 32.896828,
+            "longitude": -97.037997
+        },
+        "shield": "dallas-tx-us"
+    },
+    {
+        "code": "DAL",
+        "name": "Dallas - DAL",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 32.787,
+            "longitude": -96.794
+        },
+        "shield": "dal-tx-us"
+    },
+    {
+        "code": "DEL",
+        "name": "Delhi",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 28.506912,
+            "longitude": 77.378557
+        },
+        "shield": "del-delhi-in"
+    },
+    {
+        "code": "DEN",
+        "name": "Denver",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 39.861656,
+            "longitude": -104.673178
+        },
+        "shield": "den-co-us"
+    },
+    {
+        "code": "DUB",
+        "name": "Dublin",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 53.35,
+            "longitude": 6.26
+        },
+        "shield": "dub-dublin-ie"
+    },
+    {
+        "code": "FRA",
+        "name": "Frankfurt",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 50.026421,
+            "longitude": 8.543125
+        },
+        "shield": "frankfurt-de"
+    },
+    {
+        "code": "HHN",
+        "name": "Frankfurt - Interxion",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 50.11975,
+            "longitude": 8.738472
+        },
+        "shield": "hhn-frankfurt-de"
+    },
+    {
+        "code": "FJR",
+        "name": "Fujairah Al Mahta",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 25.112225,
+            "longitude": 56.323964
+        },
+        "shield": "fjr-ae"
+    },
+    {
+        "code": "HEL",
+        "name": "Helsinki",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 60.1699,
+            "longitude": 24.9384
+        },
+        "shield": "hel-helsinki-fi"
+    },
+    {
+        "code": "HKG",
+        "name": "Hong Kong",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 22.308919,
+            "longitude": 113.914603
+        },
+        "shield": "hongkong-hk"
+    },
+    {
+        "code": "IAH",
+        "name": "Houston",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 29.99022,
+            "longitude": -95.336783
+        },
+        "shield": "iah-tx-us"
+    },
+    {
+        "code": "JAX",
+        "name": "Jacksonville",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 30.3322,
+            "longitude": -81.6557
+        },
+        "shield": "jax-fl-us"
+    },
+    {
+        "code": "JNB",
+        "name": "Johannesburg",
+        "group": "South Africa",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -26.13778,
+            "longitude": 28.19756
+        },
+        "shield": "jnb-johannesburg-za"
+    },
+    {
+        "code": "MCI",
+        "name": "Kansas City",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 39.101,
+            "longitude": -94.581
+        }
+    },
+    {
+        "code": "LIM",
+        "name": "Lima",
+        "group": "Lima",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -12.088902,
+            "longitude": -76.973405
+        }
+    },
+    {
+        "code": "LCY",
+        "name": "London - LCY",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 51.505278,
+            "longitude": 0.055278
+        },
+        "shield": "london_city-uk"
+    },
+    {
+        "code": "LHR",
+        "name": "London - LHR",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 51.4775,
+            "longitude": -0.461389
+        },
+        "shield": "london-uk"
+    },
+    {
+        "code": "LON",
+        "name": "London - LON",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 51.499,
+            "longitude": -0.011
+        },
+        "shield": "lon-london-uk"
+    },
+    {
+        "code": "LGB",
+        "name": "Los Angeles (Metro)",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 33.942536,
+            "longitude": -118.408075
+        },
+        "shield": "lgb-ca-us"
+    },
+    {
+        "code": "BUR",
+        "name": "Los Angeles - BUR",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 34.198312,
+            "longitude": -118.357404
+        },
+        "shield": "bur-ca-us"
+    },
+    {
+        "code": "LAX",
+        "name": "Los Angeles - LAX",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 33.942536,
+            "longitude": -118.408075
+        }
+    },
+    {
+        "code": "MAD",
+        "name": "Madrid",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.439323,
+            "longitude": -3.621211
+        },
+        "shield": "mad-madrid-es"
+    },
+    {
+        "code": "MAN",
+        "name": "Manchester",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 53.4808,
+            "longitude": -2.2426
+        },
+        "shield": "man-manchester-uk"
+    },
+    {
+        "code": "MRS",
+        "name": "Marseille",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 43.311,
+            "longitude": 5.373
+        },
+        "shield": "mrs-marseille-fr"
+    },
+    {
+        "code": "MEL",
+        "name": "Melbourne",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -37.673333,
+            "longitude": 144.843333
+        },
+        "shield": "melbourne-au"
+    },
+    {
+        "code": "MIA",
+        "name": "Miami",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 25.79325,
+            "longitude": -80.290556
+        },
+        "shield": "miami-fl-us"
+    },
+    {
+        "code": "MXP",
+        "name": "Milan",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 45.4642,
+            "longitude": 9.19
+        },
+        "shield": "mxp-milan-it"
+    },
+    {
+        "code": "MSP",
+        "name": "Minneapolis",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 44.971401,
+            "longitude": -93.254501
+        },
+        "shield": "msp-mn-us"
+    },
+    {
+        "code": "STP",
+        "name": "Minneapolis",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 44.971401,
+            "longitude": -93.254501
+        }
+    },
+    {
+        "code": "YUL",
+        "name": "Montreal",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 45.497497,
+            "longitude": -73.570959
+        },
+        "shield": "yul-montreal-ca"
+    },
+    {
+        "code": "BOM",
+        "name": "Mumbai",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 18.975,
+            "longitude": 72.825833
+        },
+        "shield": "bom-mumbai-in"
+    },
+    {
+        "code": "JFK",
+        "name": "New York City",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.639751,
+            "longitude": -73.778925
+        }
+    },
+    {
+        "code": "LGA",
+        "name": "New York City - LGA",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.639751,
+            "longitude": -73.778925
+        },
+        "shield": "lga-ny-us"
+    },
+    {
+        "code": "EWR",
+        "name": "Newark",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 40.736844,
+            "longitude": -74.173402
+        }
+    },
+    {
+        "code": "ITM",
+        "name": "Osaka",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 34.785528,
+            "longitude": 135.438222
+        },
+        "shield": "osaka-jp"
+    },
+    {
+        "code": "OSL",
+        "name": "Oslo",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 59.922,
+            "longitude": 10.809
+        },
+        "shield": "osl-oslo-no"
+    },
+    {
+        "code": "PAO",
+        "name": "Palo Alto",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 37.454965,
+            "longitude": -122.110783
+        },
+        "shield": "pao-ca-us"
+    },
+    {
+        "code": "CDG",
+        "name": "Paris",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 48.928051,
+            "longitude": 2.35189
+        },
+        "shield": "cdg-par-fr"
+    },
+    {
+        "code": "PER",
+        "name": "Perth",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -31.940278,
+            "longitude": 115.966944
+        },
+        "shield": "perth-au"
+    },
+    {
+        "code": "PHX",
+        "name": "Phoenix",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 33.396,
+            "longitude": -111.97
+        }
+    },
+    {
+        "code": "PDX",
+        "name": "Portland",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 45.552,
+            "longitude": -122.914
+        },
+        "shield": "pdx-or-us"
+    },
+    {
+        "code": "GIG",
+        "name": "Rio de Janeiro",
+        "group": "Brazil",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -22.81341,
+            "longitude": -43.249423
+        },
+        "shield": "gig-riodejaneiro-br"
+    },
+    {
+        "code": "SJC",
+        "name": "San Jose",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 37.3626,
+            "longitude": -121.929022
+        },
+        "shield": "sjc-ca-us"
+    },
+    {
+        "code": "SCL",
+        "name": "Santiago",
+        "group": "South America",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -33.3936,
+            "longitude": -70.7935
+        }
+    },
+    {
+        "code": "CGH",
+        "name": "Sao Paulo",
+        "group": "Brazil",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -23.498,
+            "longitude": -46.815
+        },
+        "shield": "cgh-saopaulo-br"
+    },
+    {
+        "code": "GRU",
+        "name": "Sao Paulo",
+        "group": "Brazil",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -23.432075,
+            "longitude": -46.469511
+        },
+        "shield": "gru-br-sa"
+    },
+    {
+        "code": "SEA",
+        "name": "Seattle",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 47.449,
+            "longitude": -122.309306
+        },
+        "shield": "sea-wa-us"
+    },
+    {
+        "code": "QPG",
+        "name": "Singapore",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 1.350189,
+            "longitude": 103.994433
+        },
+        "shield": "qpg-singapore-sg"
+    },
+    {
+        "code": "SIN",
+        "name": "Singapore",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 1.350189,
+            "longitude": 103.994433
+        }
+    },
+    {
+        "code": "STL",
+        "name": "St.Louis",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 38.629,
+            "longitude": -90.197
+        }
+    },
+    {
+        "code": "BMA",
+        "name": "Stockholm",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 59.354372,
+            "longitude": 17.94165
+        },
+        "shield": "stockholm-bma"
+    },
+    {
+        "code": "SYD",
+        "name": "Sydney",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -33.946111,
+            "longitude": 151.177222
+        },
+        "shield": "sydney-au"
+    },
+    {
+        "code": "TYO",
+        "name": "Tokyo",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 35.617,
+            "longitude": 139.748
+        },
+        "shield": "tyo-tokyo-jp"
+    },
+    {
+        "code": "HND",
+        "name": "Tokyo - HND",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 35.622281,
+            "longitude": 139.748426
+        },
+        "shield": "hnd-tokyo-jp"
+    },
+    {
+        "code": "YYZ",
+        "name": "Toronto",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 43.677223,
+            "longitude": -79.630556
+        },
+        "shield": "yyz-on-ca"
+    },
+    {
+        "code": "YVR",
+        "name": "Vancouver",
+        "group": "United States",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 49.1967,
+            "longitude": -123.1815
+        }
+    },
+    {
+        "code": "VIE",
+        "name": "Vienna",
+        "group": "Europe",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": 48.269,
+            "longitude": 16.41
+        },
+        "shield": "vie-vienna-at"
+    },
+    {
+        "code": "WLG",
+        "name": "Wellington",
+        "group": "Asia/Pacific",
+        "coordinates": {
+            "x": 0,
+            "y": 0,
+            "latitude": -41.327221,
+            "longitude": 174.805278
+        }
+    }
+]


### PR DESCRIPTION
tl;dr;
We're giving up to _manually_ maintain our shielding list HTML in the template.

`shielding.json` is just an output from our `GET /datacenters` API endpoint:
https://developer.fastly.com/reference/api/utils/datacenter/

So going forward, all we need to do is to just update this JSON file.

### Things to consider

1. The file path for `shielding.json` JSON file
2. Error handling
3. How can we ensure `file_get_contents()` is only called when the dialog is actually opened? It seems like the PHP code in this template file is processed when accessing STORES->Configuration (or STORES->Configuration->System).