### PR TITLE
stop checking TLD length and check total length

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Domains/PushDomains.php
+++ b/Controller/Adminhtml/FastlyCdn/Domains/PushDomains.php
@@ -212,8 +212,10 @@ class PushDomains extends Action
             $newName = $new['name'];
             $newComment = $new['comment'];
             $newDomainData[$newName] = $newComment;
-            if (!preg_match('/^(?:\*\.)?(?:[-A-Za-z0-9]+\.)+[A-Za-z]{2,6}$/', $newName)) {
+            if (!preg_match('/^(?:\*\.)?(?:[-A-Za-z0-9]+\.)+[A-Za-z]{2,}$/', $newName)) {
                 throw new LocalizedException(__('Invalid domain name "'.$newName.'"'));
+            } elseif (strlen($newname) > 253) {
+                throw new LocalizedException(__('Domain name too long (must be 253 characters or less) "'.$newName.'"'));
             }
         }
         return $newDomainData;


### PR DESCRIPTION
https://www.icann.org/en/system/files/files/ua-factsheet-a4-17dec15-en.pdf

> • DO NOT rely on the length of a domain to determine validity. Strings can be up to 63 characters long.

the regex we use at the moment `[A-Za-z]{2,6}` is no longer valid for many new gTLDs these days. In fact, each individual label can have up to 63 octets (== 61 characters in printable string representation, [see](https://stackoverflow.com/a/32294443)).

https://tools.ietf.org/html/rfc1035#section-2.3.4

from RFC:

> To simplify implementations, the total length of a domain name (i.e.,
> label octets and label length octets) is restricted to 255 octets or
> less.

 so this PR stops checking the length of TLD and checks the total length of a domain name instead for simplification.