### PR TITLE
PWA-1832: Adding graphql caching by X-Magento-Cache-Id

### DIFF
--- a/Documentation/CONFIGURATION.md
+++ b/Documentation/CONFIGURATION.md
@@ -131,6 +131,10 @@ or was automatically redirected to the matching store. If the form_key cookies
 is present the visitor has been browsing around so he shouldn't be disturbed by
 dialogs or redirects.
 
+If the query is sent to the `/graphql` endpoint and the `X-Magento-Cache-Id`
+header is present then the cookie headers will be ignored in favor of the value
+in `X-Magento-Cache-Id`.
+
 ##### GeoIP Action
 
 Choose "Dialog" to show a modal dialog to the visitor. This gives him the

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,6 @@
     "description": "Fastly CDN Module for Magento 2.x",
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
-        "magento/module-config": ">=100.0.0",
-        "magento/module-store": ">=100.0.0",
-        "magento/module-page-cache": ">=100.0.0",
-        "magento/module-cache-invalidate": ">=100.0.0",
-        "magento/framework": ">=101.0.0",
         "zordius/lightncandy": "^1.2"
     },
     "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
     "description": "Fastly CDN Module for Magento 2.x",
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "magento/module-config": ">=100.0.0",
+        "magento/module-store": ">=100.0.0",
+        "magento/module-page-cache": ">=100.0.0",
+        "magento/module-cache-invalidate": ">=100.0.0",
+        "magento/framework": ">=101.0.0",
         "zordius/lightncandy": "^1.2"
     },
     "type": "magento2-module",

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -11,9 +11,9 @@
     # Make sure GraphQl requests are covered by store and currency
     if (req.http.graphql && resp.http.Vary !~ "(?i)Store, *Content-Currency") {
         if (resp.http.Vary) {
-            set resp.http.Vary = resp.http.Vary + ",Store,Content-Currency"
+            set resp.http.Vary = resp.http.Vary + ",Store,Content-Currency";
         } else {
-            set resp.http.Vary = "Store,Content-Currency"
+            set resp.http.Vary = "Store,Content-Currency";
         }
     }
 

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -8,19 +8,18 @@
         set resp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
     }
 
-    # GraphQl queries should vary on X-Magento-Cache-Id if it was supplied
-    if ( req.http.graphql && resp.http.X-Magento-Cache-Id ) {
-        set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "X-Magento-Cache-Id");
-    }
-
     # Execute only on the edge nodes
     if ( fastly.ff.visits_this_service == 0 ) {
         if ( req.http.graphql ) {
-            # GraphQl queries without X-Magento-Cache-Id should be cached locally under store and currency
-            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Authentication,Store,Content-Currency");
+            if ( resp.http.X-Magento-Cache-Id ) {
+                # GraphQl queries should be cached by the browser under X-Magento-Cache-Id if available
+                set resp.http.Vary = regsub(resp.http.Vary, "(?i)Https", "X-Magento-Cache-Id");
+            } else {
+                set resp.http.Vary = regsub(resp.http.Vary, "(?i),Https", "");
+            }
         } else {
             # Remove X-Magento-Vary and HTTPs Vary served to the user
-            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Cookie");
+            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https", "Cookie");
         }
         # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
         # compress it and we only want to do this on the edge nodes

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -8,14 +8,22 @@
         set resp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
     }
 
+    # Make sure GraphQl requests are covered by store and currency
+    if (req.http.graphql && resp.http.Vary !~ "(?i)Store, *Content-Currency") {
+        if (resp.http.Vary) {
+            set resp.http.Vary = resp.http.Vary + ",Store,Content-Currency"
+        } else {
+            set resp.http.Vary = "Store,Content-Currency"
+        }
+    }
+
     # Execute only on the edge nodes
     if ( fastly.ff.visits_this_service == 0 ) {
         if ( req.http.graphql ) {
+            set resp.http.Vary = resp.http.Vary + ",Authorization";
             if ( resp.http.X-Magento-Cache-Id ) {
                 # GraphQl queries should be cached by the browser under X-Magento-Cache-Id if available
-                set resp.http.Vary = regsub(resp.http.Vary, "(?i)Https", "X-Magento-Cache-Id");
-            } else {
-                set resp.http.Vary = regsub(resp.http.Vary, "(?i),Https", "");
+                set resp.http.Vary = resp.http.Vary + ",X-Magento-Cache-Id";
             }
         } else {
             # Remove X-Magento-Vary and HTTPs Vary served to the user

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -9,9 +9,9 @@
     }
 
     # Make sure GraphQl requests are covered by store and currency
-    if (req.http.graphql && resp.http.Vary !~ "(?i)Store, *Content-Currency") {
+    if (req.http.graphql && resp.http.Vary !~ "(?i)Store,\s*Content-Currency") {
         if (resp.http.Vary) {
-            set resp.http.Vary = resp.http.Vary + ",Store,Content-Currency";
+            set resp.http.Vary = resp.http.Vary ",Store,Content-Currency";
         } else {
             set resp.http.Vary = "Store,Content-Currency";
         }
@@ -20,10 +20,10 @@
     # Execute only on the edge nodes
     if ( fastly.ff.visits_this_service == 0 ) {
         if ( req.http.graphql ) {
-            set resp.http.Vary = resp.http.Vary + ",Authorization";
+            set resp.http.Vary = resp.http.Vary ",Authorization";
             if ( resp.http.X-Magento-Cache-Id ) {
                 # GraphQl queries should be cached by the browser under X-Magento-Cache-Id if available
-                set resp.http.Vary = resp.http.Vary + ",X-Magento-Cache-Id";
+                set resp.http.Vary = resp.http.Vary ",X-Magento-Cache-Id";
             }
         } else {
             # Remove X-Magento-Vary and HTTPs Vary served to the user

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -15,8 +15,13 @@
 
     # Execute only on the edge nodes
     if ( fastly.ff.visits_this_service == 0 ) {
-        # Remove X-Magento-Vary and HTTPs Vary served to the user
-        set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Cookie");
+        if ( req.http.graphql ) {
+            # GraphQl queries without X-Magento-Cache-Id should be cached locally under store and currency
+            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Authentication,Store,Content-Currency");
+        } else {
+            # Remove X-Magento-Vary and HTTPs Vary served to the user
+            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Cookie");
+        }
         # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
         # compress it and we only want to do this on the edge nodes
         if (resp.http.x-esi) {

--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -8,10 +8,15 @@
         set resp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
     }
 
+    # GraphQl queries should vary on X-Magento-Cache-Id if it was supplied
+    if ( req.http.graphql && resp.http.X-Magento-Cache-Id ) {
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "X-Magento-Cache-Id");
+    }
+
     # Execute only on the edge nodes
     if ( fastly.ff.visits_this_service == 0 ) {
         # Remove X-Magento-Vary and HTTPs Vary served to the user
-        set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https", "Cookie");
+        set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https(,X-Magento-Cache-Id)?", "Cookie");
         # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
         # compress it and we only want to do this on the edge nodes
         if (resp.http.x-esi) {

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -55,10 +55,13 @@
         }
     }
 
-    # Add Varying on X-Magento-Vary
+    # Add Varying on X-Magento-Vary and X-Magento-Cache-Id
     if (beresp.http.Content-Type ~ "text/(html|xml)" || req.http.graphql) {
         set beresp.http.Vary:X-Magento-Vary = "";
         set beresp.http.Vary:Https = "";
+        if (req.http.graphql) {
+            set beresp.http.Vary:X-Magento-Cache-Id = "";
+        }
     }
 
     # Just in case the Request Setting for x-pass is missing

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -59,7 +59,6 @@
     if (req.http.graphql) {
         set beresp.http.Vary:Store = "";
         set beresp.http.Vary:Content-Currency = "";
-        set beresp.http.Vary:Https = "";
     } else if (beresp.http.Content-Type ~ "text/(html|xml)") {
         set beresp.http.Vary:X-Magento-Vary = "";
         set beresp.http.Vary:Https = "";

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -110,7 +110,7 @@
     }
 
     # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
-    if (req.http.graphql && req.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
+    if (req.http.graphql && req.http.X-Magento-Cache-Id && req.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.cacheable = false;
         return (deliver);

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -113,5 +113,4 @@
     if (req.http.graphql && req.http.X-Magento-Cache-Id && req.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.cacheable = false;
-        return (deliver);
     }

--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -9,4 +9,3 @@
             set req.hash += "Authorized";
         }
     }
-    return(hash);

--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -1,0 +1,9 @@
+    unset req.http.graphql;
+    # Fastly should cache on X-Magento-Cache-Id if available, which has a bunch of variations so it should be part of the key and not a Vary factor
+    if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
+        set req.http.graphql = "1";
+        if ( req.http.X-Magento-Cache-Id ) {
+            set req.hash += req.http.X-Magento-Cache-Id;
+        }
+    }
+    return(hash);

--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -1,9 +1,6 @@
     unset req.http.graphql;
     # Fastly should cache on X-Magento-Cache-Id if available, which has a bunch of variations so it should be part of the key and not a Vary factor
-    if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
-        set req.http.graphql = "1";
-        if ( req.http.X-Magento-Cache-Id ) {
-            set req.hash += req.http.X-Magento-Cache-Id;
-        }
+    if (req.http.graphql && req.http.X-Magento-Cache-Id) {
+        set req.hash += req.http.X-Magento-Cache-Id;
     }
     return(hash);

--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -1,5 +1,12 @@
-    # Fastly should cache on X-Magento-Cache-Id if available, which has a bunch of variations so it should be part of the key and not a Vary factor
-    if (req.http.graphql && req.http.X-Magento-Cache-Id) {
-        set req.hash += req.http.X-Magento-Cache-Id;
+    if (req.http.graphql) {
+        # GraphQL should cache on X-Magento-Cache-Id if available, which has a bunch of variations so it should be part of the key and not a Vary factor
+        if (req.http.X-Magento-Cache-Id) {
+            set req.hash += req.http.X-Magento-Cache-Id;
+        }
+        # When the frontend stops sending the auth token, make sure users stop getting results cached for logged-in users
+        # Unfortunately we don't yet have a way to authenticate before hitting the cache, so this is as close as we can get for now
+        if ( req.http.Authorization ~ "^Bearer" ) {
+            set req.hash += "Authorized";
+        }
     }
     return(hash);

--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -1,4 +1,3 @@
-    unset req.http.graphql;
     # Fastly should cache on X-Magento-Cache-Id if available, which has a bunch of variations so it should be part of the key and not a Vary factor
     if (req.http.graphql && req.http.X-Magento-Cache-Id) {
         set req.hash += req.http.X-Magento-Cache-Id;

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -115,7 +115,7 @@
                 set req.url = querystring.set(req.url, "country_code", if ( req.http.geo_override, req.http.geo_override, client.geo.country_code));
             }
         }
-    } else if ( !req.http.graphql ) {
+    } else if ( req.url.path !~ "/graphql" ) {
         # Per suggestions in https://github.com/sdinteractive/SomethingDigital_PageCacheParams
         # we'll strip out query parameters used in Google AdWords, Mailchimp tracking by default
         # and allow custom parameters to be set. List of parameters is configurable in admin
@@ -157,5 +157,6 @@
 
     # GraphQL special headers handling because this area doesn't rely on X-Magento-Vary cookie
     if (req.http.graphql && !req.http.X-Magento-Cache-Id && req.http.Authorization ~ "^Bearer" ) {
+        unset req.http.graphql;
         set req.http.x-pass = "1";
     }

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -98,6 +98,12 @@
     # Make sure we lookup end user geo not shielding. More at https://docs.fastly.com/vcl/geolocation/#using-geographic-variables-with-shielding
     set client.geo.ip_override = req.http.Fastly-Client-IP;
 
+    if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
+        set req.http.graphql = "1";
+    } else {
+        unset req.http.graphql;
+    }
+
     # geoip lookup
     if (req.url.path ~ "fastlyCdn/geoip/getaction/") {
         # check if GeoIP has been already processed by client. this normally happens before essential cookies are set.

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -109,7 +109,7 @@
                 set req.url = querystring.set(req.url, "country_code", if ( req.http.geo_override, req.http.geo_override, client.geo.country_code));
             }
         }
-    } else if ( req.url.path !~ "/graphql" ) {
+    } else if ( !req.http.graphql ) {
         # Per suggestions in https://github.com/sdinteractive/SomethingDigital_PageCacheParams
         # we'll strip out query parameters used in Google AdWords, Mailchimp tracking by default
         # and allow custom parameters to be set. List of parameters is configurable in admin
@@ -149,24 +149,7 @@
         unset req.http.Cookie;
     }
 
-    unset req.http.graphql;
     # GraphQL special headers handling because this area doesn't rely on X-Magento-Vary cookie
-    if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
-        set req.http.graphql = "1";
-        if ( req.http.X-Magento-Cache-Id ) {
-            unset req.http.X-Magento-Vary;
-        } else if ( req.http.Authorization ~ "^Bearer" ) {
-            set req.http.x-pass = "1";
-        } else {
-            if (req.http.Store) {
-                set req.http.X-Magento-Vary = req.http.Store;
-            }
-            if (req.http.Content-Currency) {
-                if (req.http.X-Magento-Vary) {
-                    set req.http.X-Magento-Vary = req.http.X-Magento-Vary req.http.Content-Currency;
-                } else {
-                    set req.http.X-Magento-Vary = req.http.Content-Currency;
-                }
-            }
-        }
+    if (req.http.graphql && !req.http.X-Magento-Cache-Id && req.http.Authorization ~ "^Bearer" ) {
+        set req.http.x-pass = "1";
     }

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -152,10 +152,12 @@
     unset req.http.graphql;
     # GraphQL special headers handling because this area doesn't rely on X-Magento-Vary cookie
     if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
-        if ( req.http.Authorization ~ "^Bearer" ) {
+        set req.http.graphql = "1";
+        if ( req.http.X-Magento-Cache-Id ) {
+            unset req.http.X-Magento-Vary;
+        } else if ( req.http.Authorization ~ "^Bearer" ) {
             set req.http.x-pass = "1";
         } else {
-            set req.http.graphql = "1";
             if (req.http.Store) {
                 set req.http.X-Magento-Vary = req.http.Store;
             }


### PR DESCRIPTION
[PWA-1832](https://jira.corp.magento.com/browse/PWA-1832): Treat the X-Magento-Cache-Id header as the cache key for GraphQL requests

- Blocked by [PWA-1834](https://jira.corp.magento.com/browse/PWA-1834) to have Magento serve the header