### PR TITLE
Disable http auth for GraphQL endpoint

### DIFF
--- a/etc/vcl_snippets_basic_auth/recv.vcl
+++ b/etc/vcl_snippets_basic_auth/recv.vcl
@@ -2,7 +2,7 @@
   # locking themselves out. /oauth and /rest have their own auth so we can skip Basic Auth on them as well
   if ( table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
       !req.url ~ "^/(index\.php/)?####ADMIN_PATH####/" &&
-      !req.url ~ "^/(index\.php/)?(rest|oauth)/" &&
+      !req.url ~ "^/(index\.php/)?(rest|oauth|graphql)/" &&
       !req.url ~ "^/pub/static/" ) {
       error 771;
   }


### PR DESCRIPTION
GraphQL as rest and oauth should not be covered with HTTP Auth when it is enabled. It causes all sorts of issues as Authorization headers are used for GraphQL as well.