### PR TITLE
Remove slash from GraphQL exclusion

### DIFF
--- a/etc/vcl_snippets_basic_auth/recv.vcl
+++ b/etc/vcl_snippets_basic_auth/recv.vcl
@@ -2,8 +2,7 @@
   # locking themselves out. /oauth and /rest have their own auth so we can skip Basic Auth on them as well
   if ( table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
       !req.url ~ "^/(index\.php/)?####ADMIN_PATH####/" &&
-      !req.url ~ "^/(index\.php/)?(rest|oauth)/" &&
-      !req.url ~ "^/(index\.php/)?graphql" &&
+      !req.url ~ "^/(index\.php/)?(rest|oauth|graphql)($|[\/?])" &&
       !req.url ~ "^/pub/static/" ) {
       error 771;
   }

--- a/etc/vcl_snippets_basic_auth/recv.vcl
+++ b/etc/vcl_snippets_basic_auth/recv.vcl
@@ -2,7 +2,8 @@
   # locking themselves out. /oauth and /rest have their own auth so we can skip Basic Auth on them as well
   if ( table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
       !req.url ~ "^/(index\.php/)?####ADMIN_PATH####/" &&
-      !req.url ~ "^/(index\.php/)?(rest|oauth|graphql)/" &&
+      !req.url ~ "^/(index\.php/)?(rest|oauth)/" &&
+      !req.url ~ "^/(index\.php/)?graphql" &&
       !req.url ~ "^/pub/static/" ) {
       error 771;
   }


### PR DESCRIPTION
GraphQL is usually called without a slash at the end of the URL.