### PR TITLE
prevent PURGE requests from being blocked by custom modules

### DIFF
--- a/etc/vcl_snippets_basic_auth/recv.vcl
+++ b/etc/vcl_snippets_basic_auth/recv.vcl
@@ -1,6 +1,7 @@
   # Check Basic auth against a table. /admin URLs are not basic auth protected to avoid the possibility of people
   # locking themselves out. /oauth and /rest have their own auth so we can skip Basic Auth on them as well
-  if ( table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
+  if ( req.method != "FASTLYPURGE" &&
+      table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
       !req.url ~ "^/(index\.php/)?####ADMIN_PATH####/" &&
       !req.url ~ "^/(index\.php/)?(rest|oauth|graphql)/" &&
       !req.url ~ "^/pub/static/" ) {

--- a/etc/vcl_snippets_blocking/recv.vcl
+++ b/etc/vcl_snippets_blocking/recv.vcl
@@ -1,5 +1,5 @@
    # Make sure we lookup end user geo not shielding. More at https://docs.fastly.com/vcl/geolocation/#using-geographic-variables-with-shielding
    set client.geo.ip_override = req.http.Fastly-Client-IP;
-   if (####BLOCKED_ITEMS####) {
+   if (req.method != "FASTLYPURGE" && ( ####BLOCKED_ITEMS#### )) {
       error 405 "Not allowed";
    }


### PR DESCRIPTION
PURGE should be safe to bypass these block rules as we require auth for PURGE anyway (ie., `Fastly-Purge-Requires-Auth`).