### PR TITLE
Fix/issue 466

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -45,7 +45,7 @@ class Config extends \Magento\PageCache\Model\Config
     /**
      * Cache types
      */
-    const FASTLY = 'fastly';
+    const FASTLY = 42;
 
     /**
      * Magento module prefix used for naming vcl snippets, condition and request

--- a/Model/PageCache/ConfigPlugin.php
+++ b/Model/PageCache/ConfigPlugin.php
@@ -18,6 +18,7 @@
  * @copyright   Copyright (c) 2016 Fastly, Inc. (http://www.fastly.com)
  * @license     BSD, see LICENSE_FASTLY_CDN.txt
  */
+
 namespace Fastly\Cdn\Model\PageCache;
 
 use \Magento\PageCache\Model\Config;
@@ -36,6 +37,18 @@ use \Magento\PageCache\Model\Config;
  */
 class ConfigPlugin
 {
+    protected $_scopeConfig;
+
+    /**
+     * ConfigPlugin constructor.
+     *
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(\Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig)
+    {
+        $this->_scopeConfig = $scopeConfig;
+    }
+
     /**
      * Return cache type "Varnish" if Fastly is configured.
      *
@@ -50,6 +63,23 @@ class ConfigPlugin
             if ($result == \Fastly\Cdn\Model\Config::FASTLY) {
                 return Config::VARNISH;
             }
+        }
+        return $result;
+    }
+
+    /**
+     * Change return value from string to int, 'fastly' is old value
+     *
+     * @param Config $config
+     * @param callable $proceed
+     * @return string
+     */
+    public function aroundGetType(Config $config, callable $proceed)
+    {
+        if ($this->_scopeConfig->getValue(Config::XML_PAGECACHE_TYPE) === 'fastly') {
+            $result = \Fastly\Cdn\Model\Config::FASTLY;
+        } else {
+            $result = $proceed();
         }
         return $result;
     }

--- a/Model/PageCache/ConfigPlugin.php
+++ b/Model/PageCache/ConfigPlugin.php
@@ -72,7 +72,7 @@ class ConfigPlugin
      *
      * @param Config $config
      * @param callable $proceed
-     * @return string
+     * @return string|int
      */
     public function aroundGetType(Config $config, callable $proceed)
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fastly/magento2",
     "description": "Fastly CDN Module for Magento 2.x",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
         "magento/module-config": ">=100.0.0",
         "magento/module-store": ">=100.0.0",
         "magento/module-page-cache": ">=100.0.0",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -935,7 +935,7 @@
                         </field>
                     </group>
                     <depends>
-                        <field id="caching_application">fastly</field>
+                        <field id="caching_application">42</field>
                     </depends>
                 </group>
                 <!-- =============================
@@ -945,7 +945,7 @@
                     <label>Fastly Edge Modules</label>
                     <comment><![CDATA[Fastly Edge module allow you to enable specific functionality like CORS headers, etc. For more details <a href="https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/Edge-Modules/EDGE-MODULES.md" target="_blank">click here.</a>]]></comment>
                     <depends>
-                        <field id="caching_application">fastly</field>
+                        <field id="caching_application">42</field>
                         <field id="system/full_page_cache/fastly/fastly_advanced_configuration/enable_fastly_edge_modules">1</field>
                     </depends>
                     <!-- =========================

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,7 +21,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Fastly_Cdn" setup_version="1.0.14">
+    <module name="Fastly_Cdn" setup_version="1.0.15">
         <sequence>
             <module name="Magento_Store"/>
             <module name="Magento_PageCache" />


### PR DESCRIPTION
This is fix for #466 
now, fastly constant has int values = 42

also we removed support for php version 5.x