### PR TITLE
Dropping Authorization from graphql hash

### DIFF
--- a/etc/vcl_snippets/hash.vcl
+++ b/etc/vcl_snippets/hash.vcl
@@ -8,4 +8,10 @@
         if ( req.http.Authorization ~ "^Bearer" ) {
             set req.hash += "Authorized";
         }
+
+        set req.hash += req.url;
+        set req.hash += req.http.Host;
+        set req.hash += req.http.Fastly-SSL;
+        set req.hash += req.vcl.generation;
+        return (hash);
     }

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -105,7 +105,7 @@
     # Make sure we lookup end user geo not shielding. More at https://docs.fastly.com/vcl/geolocation/#using-geographic-variables-with-shielding
     set client.geo.ip_override = req.http.Fastly-Client-IP;
 
-    if (req.request == "GET" && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
+    if ((req.request == "GET" || req.request == "HEAD") && req.url.path ~ "/graphql" && req.url.qs ~ "query=") {
         set req.http.graphql = "1";
     } else {
         unset req.http.graphql;


### PR DESCRIPTION
This code is in the framework code for the hash subroutine:
```
  if( req.url ) {
    set req.hash += req.url;
    set req.hash += req.http.Host;
    set req.hash += req.http.Authorization;
    set req.hash += req.http.Fastly-SSL;
    set req.hash += req.vcl.generation;
    return (hash);
  }
```

However, `req.http.Authorization` being included in the hash means that every single user will get a different request id, which is not desired; the cache should be shared between users.

To fix this, this PR takes that same block but omits the Authorization header and returns before the Fastly-side code runs.