### PR TITLE
Proper way for mixing gallery widget

### DIFF
--- a/view/frontend/web/js/gallery/gallery-mixin.js
+++ b/view/frontend/web/js/gallery/gallery-mixin.js
@@ -5,28 +5,29 @@ define([
     'use strict';
 
     return function (gallery) {
+        return gallery.extend({
+            initialize: function (config, element) {
+                if (_.isUndefined(config) || _.isEmpty(config))
+                    return this._super(config, element);
 
-        return wrapper.wrap(gallery, function (initialize, config, element) {
-            if (_.isUndefined(config) || _.isEmpty(config))
-                return initialize(config, element);
+                if (_.isUndefined(config.data) || _.isEmpty(config.data))
+                    return this._super(config, element);
 
-            if (_.isUndefined(config.data) || _.isEmpty(config.data))
-                return initialize(config, element);
+                let wdpr = window.devicePixelRatio;
 
-            let wdpr = window.devicePixelRatio;
+                _.each(config.data, function (imageObject) {
 
-            _.each(config.data, function (imageObject) {
+                    if (_.isUndefined(imageObject.fastly_srcset))
+                        return;
 
-                if (_.isUndefined(imageObject.fastly_srcset))
-                    return;
+                    if (!_.has(imageObject.fastly_srcset, wdpr))
+                        return;
 
-                if (!_.has(imageObject.fastly_srcset, wdpr))
-                    return;
+                    imageObject.img = imageObject.fastly_srcset[wdpr];
+                });
 
-                imageObject.img = imageObject.fastly_srcset[wdpr];
-            });
-
-            initialize(config, element);
+                this._super(config, element);
+            }
         });
     };
 });


### PR DESCRIPTION
Method **wrapper.wrap** is good for mixing functions, but definitely not suitable for mixing objects like **gallery** widget.
For mixing **gallery** widget it is better to use **.extend** method.
