### PR TITLE
Make the image custom attributes extendable

### DIFF
--- a/Plugin/AdaptivePixelRatioPlugin.php
+++ b/Plugin/AdaptivePixelRatioPlugin.php
@@ -80,7 +80,8 @@ class AdaptivePixelRatioPlugin
         }
 
         if (version_compare($this->productMetadata->getVersion(), '2.4', '<')) {
-            $subject->setData('custom_attributes', 'srcset="' . implode(',', $srcSet) . '"');
+            $subject->setData('custom_attributes',
+                'srcset="' . implode(',', $srcSet) . '" ' . $subject->getData('custom_attributes'));
         } else {
             $customAttributes = $subject->getCustomAttributes() ?: [];
             $customAttributes['srcset'] = implode(',', $srcSet);

--- a/Plugin/AdaptivePixelRatioPlugin.php
+++ b/Plugin/AdaptivePixelRatioPlugin.php
@@ -79,12 +79,15 @@ class AdaptivePixelRatioPlugin
             $srcSet[] = $imageUrl . $glue . $ratio;
         }
 
+        $srcSet = implode(',', $srcSet);
+        $customAttributes = $subject->getCustomAttributes();
         if (version_compare($this->productMetadata->getVersion(), '2.4', '<')) {
-            $subject->setData('custom_attributes',
-                'srcset="' . implode(',', $srcSet) . '" ' . $subject->getData('custom_attributes'));
+            $customAttributes = !empty($customAttributes) ? [$customAttributes] : [];
+            $customAttributes[] = 'srcset="' . $srcSet . '"';
+            $subject->setData('custom_attributes', implode(' ', $customAttributes));
         } else {
-            $customAttributes = $subject->getCustomAttributes() ?: [];
-            $customAttributes['srcset'] = implode(',', $srcSet);
+            $customAttributes = $customAttributes ?: [];
+            $customAttributes['srcset'] = $srcSet;
             $subject->setData('custom_attributes', $customAttributes);
         }
     }


### PR DESCRIPTION
Fix for issue: https://github.com/fastly/fastly-magento2/issues/473

Image custom attributes are not extendable for Magento versions lower than 2.4