### PR TITLE
ESI workaround snippet no longer required

### DIFF
--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -40,12 +40,6 @@
         }
     }
 
-    # Fixup for Varnish ESI not dealing with https:// absolute URLs well
-    if (req.is_esi_subreq && req.url ~ "/https://([^/]+)(/.*)$") {
-        set req.http.Host = re.group.1;
-        set req.url = re.group.2;
-    }
-
     unset req.http.x-long-cache;
 
     # We want to force long cache times on any of the versioned assets


### PR DESCRIPTION
This was fixed in 2018 and Fastly Varnish can correctly handle absolute URLs regardless of the schema type since then. Removing this old workaround snippet to reduce future confusion.

---

### Origin

```sh
$ curl -s 'https://shohei-mage-esi-poc.global.ssl.fastly.net/'
<html><body>ESI: <esi:include src='https://shohei-mage-esi-poc.global.ssl.fastly.net/esi'/></body></html>

$ curl -s 'https://shohei-mage-esi-poc.global.ssl.fastly.net/esi'
esi body - edited :)
```

### CDN front

```sh
$ curl -s 'https://shohei-esi-poc-front.global.ssl.fastly.net/'
<html><body>ESI: esi body - edited :)</body></html>
```