### PR TITLE
Fix ambiguous behavior in Blocking toggle

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1365,7 +1365,7 @@ class Config extends \Magento\PageCache\Model\Config
      */
     public function processBlockedItems($strippedBlockedItems, $blockingType = null)
     {
-        if (empty($blockingType)) {
+        if (is_null($blockingType)) {
             $blockingType = $this->_scopeConfig->getValue(self::XML_FASTLY_BLOCKING_TYPE);
         }
         if ($blockingType == '1') {

--- a/view/adminhtml/web/js/blocking.js
+++ b/view/adminhtml/web/js/blocking.js
@@ -177,7 +177,7 @@ define([
                     title: 'Blocking Type: Allowlist',
                     content: 'Turning on this feature will block ALL access except for users from designated countries/ACLs. ' +
                         'Please make sure you as the admin user are in one of the lists since you WILL lose access to the admin pages. ' +
-                        'Only way to fix it is via Fastly management UI. Please type I ACKNOWLEDGE' +
+                        'Only way to fix it is via Fastly management UI. Please type "I ACKNOWLEDGE"' +
                         ' in the box below if you are sure you want to do this.',
                     actions: {
                         confirm: function (input) {
@@ -213,7 +213,10 @@ define([
                 url: config.toggleBlockingSettingUrl,
                 data: {
                     'activate_flag': activate_blocking_flag,
-                    'active_version': active_version
+                    'active_version': active_version,
+                    'acls': $('#system_full_page_cache_fastly_fastly_blocking_block_by_acl').serializeArray(),
+                    'countries': $('#system_full_page_cache_fastly_fastly_blocking_block_by_country').serializeArray(),
+                    'blocking_type': $('#system_full_page_cache_fastly_fastly_blocking_blocking_type').val()
                 },
                 showLoader: true,
                 success: function (response) {


### PR DESCRIPTION
We're ignoring the UI selections (countries and acls) at the time of the toggle button click (Enable/Disable) and rather reading the previous state from the saved config data.

This behavior is very confusing and should be considered a bug. For example, with this scenario:

1. Enable blocking with `Allowlist` and disable it
2. Change the `Blocking Type` to `Blocklist` and enable it again

This will create an `Allowlist` VCL snippet. We should respect the UI selections rather than the previous state.

Also, another problem is that we're only updating the config when the `Update Blocking Config` button is clicked.

This PR fixes them so that we respect the UI selections as well as update the config data upon toggling.