### PR TITLE
Apply request processing only when Fastly is enabled

### DIFF
--- a/Model/FrontControllerPlugin.php
+++ b/Model/FrontControllerPlugin.php
@@ -124,6 +124,10 @@ class FrontControllerPlugin
      */
     public function aroundDispatch(FrontControllerInterface $subject, callable $proceed, ...$args) // @codingStandardsIgnoreLine - unused parameter
     {
+        if (!$this->config->isFastlyEnabled()) {
+            return $proceed(...$args);
+        }
+
         $isRateLimitingEnabled = $this->config->isRateLimitingEnabled();
         $isCrawlerProtectionEnabled = $this->config->isCrawlerProtectionEnabled();
 


### PR DESCRIPTION
# Issue
When Fastly has been previously in use, but is no longer in use, some Fastly settings are still effective.

We have noticed this when working on development and staging copies of a website where Fastly is configured properly on production, but not in use on development nor staging environments; Magento is configured in these environments to use 'built-in' or 'varnish' as its full-page cache application.

## Steps to reproduce
1. Configure Magento to use Fastly as its Full-Page Cache.
1. Configure Rate Limiting in the Fastly-specific settings.
1. Navigate to the front-end and exceed the configured rate limiting threshold.
1. Witness that Fastly rate limiting is effective.
1. Configure Magento to use another application for Full-Page Cache (such as 'built-in').
1. Witness that Fastly rate limiting is effective, even though Magento is not configured to use Fastly at all.