### PR TITLE
Do not send `override_host` if empty upon backend creation

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Backend/CreateBackend.php
+++ b/Controller/Adminhtml/FastlyCdn/Backend/CreateBackend.php
@@ -115,6 +115,7 @@ class CreateBackend extends Action
             }
 
             $override = $this->validateOverride($this->getRequest()->getParam('override_host'));
+            $override = $override === '' ? null : $override;
 
             $name = $this->getRequest()->getParam('name');
             $this->validateName($name);


### PR DESCRIPTION
This is confusing though we do need to send an empty string upon the "update" operation (PUT) in case users want to clear this field value, but we must not send it for the "create" operation as the Fastly API strictly validates the `override_host` value upon POST.