### PR TITLE
Added support for Allow Headers #492

### DIFF
--- a/etc/fastly_edge_modules/cors_headers.json
+++ b/etc/fastly_edge_modules/cors_headers.json
@@ -24,6 +24,13 @@
             "type": "string"
         },
         {
+          "description": "Allowed HTTP Headers that requestor can use",
+          "label": "Allowed HTTP Headers",
+          "name": "cors_allowed_headers",
+          "required": false,
+          "type": "string"
+        },
+        {
             "description": "Regex matching origins that are allowed to access this service",
             "label": "Regex matching origins",
             "name": "cors_allowed_origins_regex",
@@ -39,7 +46,7 @@
     },
     "vcl": [
         {
-            "template": "  if (req.http.Origin && !resp.http.Access-Control-Allow-Origin && !resp.http.Access-Control-Allow-Methods) {\n{{#ifEq origin \"anyone\"}}\n    set resp.http.Access-Control-Allow-Origin = \"*\";\n{{/ifEq}}\n{{#ifEq origin \"regex-match\"}}\n    if ( req.http.Origin ~ \"^https?://{{cors_allowed_origins_regex}}\" ) {\n      set resp.http.Access-Control-Allow-Origin = req.http.origin;\n    }\n{{/ifEq}}\n    set resp.http.Access-Control-Allow-Methods = \"{{cors_allowed_methods}}\";\n    set resp.http.Vary:Origin = \"\";\n  \n  }\n",
+            "template": "  if (req.http.Origin && !resp.http.Access-Control-Allow-Origin && !resp.http.Access-Control-Allow-Methods && !resp.http.Access-Control-Allow-Headers) {\n{{#ifEq origin \"anyone\"}}\n    set resp.http.Access-Control-Allow-Origin = \"*\";\n{{/ifEq}}\n{{#ifEq origin \"regex-match\"}}\n    if ( req.http.Origin ~ \"^https?://{{cors_allowed_origins_regex}}\" ) {\n      set resp.http.Access-Control-Allow-Origin = req.http.origin;\n    }\n{{/ifEq}}\n    set resp.http.Access-Control-Allow-Methods = \"{{cors_allowed_methods}}\";\n{{#if cors_allowed_headers}}\n    set resp.http.Access-Control-Allow-Headers = \"{{cors_allowed_headers}}\";\n{{/if}}\n    set resp.http.Vary:Origin = \"\";\n  \n  }\n",
             "type": "deliver"
         }
     ],


### PR DESCRIPTION
Closes #492 

this is example from VCL file when CORS headers are enabled:
`# Snippet edgemodule_cors_headers_deliver : 45
  if (req.http.Origin && !resp.http.Access-Control-Allow-Origin && !resp.http.Access-Control-Allow-Methods && !resp.http.Access-Control-Allow-Headers) {
    if ( req.http.Origin ~ "^https?://google.hr" ) {
      set resp.http.Access-Control-Allow-Origin = req.http.origin;
    }
    set resp.http.Access-Control-Allow-Methods = "GET,HEAD,POST,OPTIONS";
    set resp.http.Access-Control-Allow-Headers = "Content-Type,X-company";
    set resp.http.Vary:Origin = "";
  }`

and configuration:

![Screenshot from 2021-11-09 11-53-21](https://user-images.githubusercontent.com/553247/140911583-80b42d6a-0a81-4ba9-988f-65b72e76610a.png)

It is tested fetch from different domains and with different headers.