### PR TITLE
Add GitHub Actions to automate updating `datacenters.json`

### DIFF
--- a/.github/workflows/delete-bot-branch.yaml
+++ b/.github/workflows/delete-bot-branch.yaml
@@ -1,0 +1,19 @@
+name: Delete bot branch on PR close/merge
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  delete-bot-branch:
+    if: startsWith(${{ github.head_ref }}, "datacenters-json-auto-update-")
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Delete branch
+      run: |
+        git config user.name "github-actions"
+        git config user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+        git push origin --delete "${{ github.head_ref }}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shielding-check-cron-manual.yaml
+++ b/.github/workflows/shielding-check-cron-manual.yaml
@@ -1,0 +1,44 @@
+name: Datacenters check cron job (manual kick)
+on: [ workflow_dispatch ]
+jobs:
+  check-diff-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Fetch latest JSON via Fastly API
+      run: |
+        curl -s https://api.fastly.com/datacenters -H "fastly-key: ${FASTLY_API_KEY}" --fail -o ./temp.json
+      env:
+        FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
+    - name: Update JSON
+      id: update-json
+      if: success()
+      run: |
+        cat ./temp.json | jq . > etc/shielding/datacenters.json
+        rm -f ./temp.json
+        echo "::set-output name=diff-count::$(git diff --name-only | wc -l)"
+        SHA1=`sha1sum etc/shielding/datacenters.json | awk '{print $1}'`
+        echo "::set-output name=sha1::$SHA1"
+        echo "::set-output name=pr-count::$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check diff and create PR
+      if: |
+        steps.update-json.outputs.pr-count == 0 &&
+        steps.update-json.outputs.diff-count > 0
+      run: |
+        DATE=`date +"%Y%m%d"`
+        BRANCH_NAME="datacenters-json-auto-update-${DATE}"
+        git config user.name "github-actions"
+        git config user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+        git checkout -b "${BRANCH_NAME}"
+        git add .
+        git commit -m "Update datacenters.json"
+        git push origin "${BRANCH_NAME}"
+        gh pr create --title "Update datacenters.json - ${{ steps.update-json.outputs.sha1 }}" --base master --head "${BRANCH_NAME}" \
+        --body "Submitted by GitHub Actions automation.
+
+        You may want to close old bot PRs if they haven't merged yet."
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shielding-check-cron.yaml
+++ b/.github/workflows/shielding-check-cron.yaml
@@ -1,0 +1,47 @@
+name: Datacenters check cron job
+on:
+  schedule:
+    # UTC, at midnight every day
+    - cron: "0 0 * * *"
+jobs:
+  check-diff-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Fetch latest JSON via Fastly API
+      run: |
+        curl -s https://api.fastly.com/datacenters -H "fastly-key: ${FASTLY_API_KEY}" --fail -o ./temp.json
+      env:
+        FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
+    - name: Update JSON
+      id: update-json
+      if: success()
+      run: |
+        cat ./temp.json | jq . > etc/shielding/datacenters.json
+        rm -f ./temp.json
+        echo "::set-output name=diff-count::$(git diff --name-only | wc -l)"
+        SHA1=`sha1sum etc/shielding/datacenters.json | awk '{print $1}'`
+        echo "::set-output name=sha1::$SHA1"
+        echo "::set-output name=pr-count::$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check diff and create PR
+      if: |
+        steps.update-json.outputs.pr-count == 0 &&
+        steps.update-json.outputs.diff-count > 0
+      run: |
+        DATE=`date +"%Y%m%d"`
+        BRANCH_NAME="datacenters-json-auto-update-${DATE}"
+        git config user.name "github-actions"
+        git config user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+        git checkout -b "${BRANCH_NAME}"
+        git add .
+        git commit -m "Update datacenters.json"
+        git push origin "${BRANCH_NAME}"
+        gh pr create --title "Update datacenters.json - ${{ steps.update-json.outputs.sha1 }}" --base master --head "${BRANCH_NAME}" \
+        --body "Submitted by GitHub Actions automation.
+
+        You may want to close old bot PRs if they haven't merged yet."
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
ref. https://github.com/fastly/fastly-magento2/tree/master/etc/shielding

This will run at midnight every day and open a PR if any diff is detected. And the workflow stops jobs if there's an existing PR for that to not submit duplicate PRs. Therefore, the PR title will include a hash of the target file that is used as a search keyword.