### PR TITLE
According to your docs -> https://github.com/fastly/fastly-magento2/b…

### DIFF
--- a/etc/vcl_snippets_rate_limiting/recv.vcl
+++ b/etc/vcl_snippets_rate_limiting/recv.vcl
@@ -1,8 +1,10 @@
 if (####RATE_LIMITED_PATHS####) {
-  set req.http.Rate-Limit = "1";
-  set req.http.X-Orig-Method = req.method;
-  set req.hash_ignore_busy = true;
-  if (req.method !~ "^(GET|POST)$") {
-    set req.method = "POST";
+  if (req.http.Fastly-Client-Ip !~ maint_allowlist) {
+      set req.http.Rate-Limit = "1";
+      set req.http.X-Orig-Method = req.method;
+      set req.hash_ignore_busy = true;
+      if (req.method !~ "^(GET|POST)$") {
+        set req.method = "POST";
+      }
   }
 }


### PR DESCRIPTION
According to your [docs](https://github.com/fastly/fastly-magento2/blob/master/Documentation/Guides/RATE-LIMITING.md).

```
Following users are exempt from blocking:
IPs defined in var/.maintenance.ip (See Maintenance Mode guide for more details)
```

var/.maintenance.ip updates acl maint_allowlist but this acl is never used to exempt the ips from getting blocked.
As a result rate limit will return 429 also for IPs that are on the maintenance list.

#556 