### PR TITLE
fix getImageOptimization PHP 8.1

### DIFF
--- a/Block/System/Config/Form/Field/Checkbox.php
+++ b/Block/System/Config/Form/Field/Checkbox.php
@@ -96,16 +96,12 @@ class Checkbox extends Field
     /**
      * Get checked values
      *
-     * @return array|null
+     * @return array
      */
     public function getCheckedValues()
     {
         if ($this->values === null) {
-            $data = $this->config->getImageOptimizationRatios();
-            if (!isset($data)) {
-                $data = '';
-            }
-            $this->values = explode(',', $data);
+            $this->values = $this->config->getImageOptimizationRatios();
         }
         return $this->values;
     }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -847,7 +847,7 @@ class Config extends \Magento\PageCache\Model\Config
      */
     public function getImageOptimizationRatios()
     {
-        return (string)$this->_scopeConfig->getvalue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
+        return (string)$this->_scopeConfig->getValue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -843,11 +843,16 @@ class Config extends \Magento\PageCache\Model\Config
     /**
      * Return image optimization pixel ratios
      *
-     * @return string
+     * @return array
      */
     public function getImageOptimizationRatios()
     {
-        return (string)$this->_scopeConfig->getValue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
+        $result = [];
+        $data = (string)$this->_scopeConfig->getValue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
+        if ($data) {
+            $result = \explode(',', $data);
+        }
+        return $result;
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -843,11 +843,11 @@ class Config extends \Magento\PageCache\Model\Config
     /**
      * Return image optimization pixel ratios
      *
-     * @return mixed
+     * @return string
      */
     public function getImageOptimizationRatios()
     {
-        return $this->_scopeConfig->getvalue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
+        return (string)$this->_scopeConfig->getvalue(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_RATIOS);
     }
 
     /**
@@ -1392,12 +1392,12 @@ class Config extends \Magento\PageCache\Model\Config
      * Process blocked items depending on blocking type
      *
      * @param $strippedBlockedItems
-     * @param null $blockingType
-     * @return string
+     * @param null|string $blockingType
+     * @return mixed|string
      */
     public function processBlockedItems($strippedBlockedItems, $blockingType = null)
     {
-        if (is_null($blockingType)) {
+        if ($blockingType === null) {
             $blockingType = $this->_scopeConfig->getValue(self::XML_FASTLY_BLOCKING_TYPE);
         }
         if ($blockingType == '1') {

--- a/Plugin/AdaptivePixelRatioPlugin.php
+++ b/Plugin/AdaptivePixelRatioPlugin.php
@@ -25,9 +25,8 @@ use Magento\Catalog\Block\Product\Image;
 use Magento\Framework\App\ProductMetadataInterface;
 
 /**
- * Class AdaptivePixelRatioPlugin
+ * Class AdaptivePixelRatioPlugin for image ration
  *
- * @package Fastly\Cdn\Plugin
  */
 class AdaptivePixelRatioPlugin
 {
@@ -68,8 +67,7 @@ class AdaptivePixelRatioPlugin
 
         $srcSet = [];
         $imageUrl = $subject->getData('image_url');
-        $pixelRatios = $this->config->getImageOptimizationRatios();
-        $pixelRatiosArray = explode(',', $pixelRatios);
+        $pixelRatiosArray = $this->config->getImageOptimizationRatios();
         $glue = (strpos($imageUrl, '?') !== false) ? '&' : '?';
 
         # Pixel ratios defaults are based on the table from https://mydevice.io/devices/

--- a/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
+++ b/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
@@ -8,8 +8,7 @@ use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
 use Magento\Framework\Serialize\SerializerInterface;
 
 /**
- * Class ConfigurablePlugin
- * @package Fastly\Cdn\Plugin\Block\Product\View\Type
+ * Class ConfigurablePlugin After Get JsonConfig
  */
 class ConfigurablePlugin
 {
@@ -45,28 +44,36 @@ class ConfigurablePlugin
     }
 
     /**
+     * After Get JsonConfig
+     *
      * @param Configurable $subject
      * @param string $result
      * @return bool|string
      */
     public function afterGetJsonConfig(Configurable $subject, string $result)
     {
-        if (!$this->config->isImageOptimizationPixelRatioEnabled() || !$result)
+        if (!$this->config->isImageOptimizationPixelRatioEnabled() || !$result) {
             return $result;
+        }
 
-        if (!$config = $this->serializer->unserialize($result))
+        if (!$config = $this->serializer->unserialize($result)) {
             return $result;
+        }
 
-        if (!isset($config['images']))
+        if (!isset($config['images'])) {
             return $result;
+        }
 
-        if (!$pixelRatios = explode(',', $this->config->getImageOptimizationRatios()))
+        $pixelRatios = $this->config->getImageOptimizationRatios();
+        if (empty($pixelRatios)) {
             return $result;
+        }
 
         foreach ($config['images'] as &$images) {
             foreach ($images as &$image) {
-                if (!isset($image['img']))
+                if (!isset($image['img'])) {
                     continue;
+                }
 
                 $image['fastly_srcset'] = $this->adaptivePixelRatio->generateSrcSet($image['img'], $pixelRatios);
             }

--- a/Plugin/GalleryPlugin.php
+++ b/Plugin/GalleryPlugin.php
@@ -8,8 +8,7 @@ use Magento\Catalog\Block\Product\View\Gallery;
 use Magento\Framework\Serialize\SerializerInterface;
 
 /**
- * Class GalleryPlugin
- * @package Fastly\Cdn\Plugin
+ * Class GalleryPlugin for applying image optimization
  */
 class GalleryPlugin
 {
@@ -30,6 +29,7 @@ class GalleryPlugin
 
     /**
      * GalleryPlugin constructor.
+     *
      * @param SerializerInterface $serializer
      * @param AdaptivePixelRatio $adaptivePixelRatio
      * @param Config $config
@@ -45,28 +45,35 @@ class GalleryPlugin
     }
 
     /**
+     * After Get Gallery Images Json
+     *
      * @param Gallery $subject
      * @param string|false $result
      * @return false|string
      */
-   public function afterGetGalleryImagesJson(Gallery $subject, $result)
-   {
-       if (!$this->config->isImageOptimizationPixelRatioEnabled() || !$result)
-           return $result;
+    public function afterGetGalleryImagesJson(Gallery $subject, $result)
+    {
+        if (!$this->config->isImageOptimizationPixelRatioEnabled() || !$result) {
+            return $result;
+        }
 
-       if (!$images = $this->serializer->unserialize($result))
-           return $result;
+        if (!$images = $this->serializer->unserialize($result)) {
+            return $result;
+        }
 
-       if (!$pixelRatios = explode(',', $this->config->getImageOptimizationRatios()))
-           return $result;
+        $pixelRatios = $this->config->getImageOptimizationRatios();
+        if (empty($pixelRatios)) {
+            return $result;
+        }
 
-       foreach ($images as &$image) {
-           if (!isset($image['img']))
-               continue;
+        foreach ($images as &$image) {
+            if (!isset($image['img'])) {
+                continue;
+            }
 
-           $image['fastly_srcset'] = $this->adaptivePixelRatio->generateSrcSet($image['img'], $pixelRatios);
-       }
+            $image['fastly_srcset'] = $this->adaptivePixelRatio->generateSrcSet($image['img'], $pixelRatios);
+        }
 
-       return $this->serializer->serialize($images);
-   }
+        return $this->serializer->serialize($images);
+    }
 }


### PR DESCRIPTION
This is fix for error:
`Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /app/dkq5e2qiq3clq_stg/vendor/fastly/magento2/Plugin/GalleryPlugin.php on line 60 in /app/dkq5e2qiq3clq_stg/vendor/magento/framework/App/ErrorHandler.php:61`