### PR TITLE
Rate limiting: Fix for path processing

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/RateLimiting/ToggleRateLimiting.php
+++ b/Controller/Adminhtml/FastlyCdn/RateLimiting/ToggleRateLimiting.php
@@ -271,14 +271,14 @@ class ToggleRateLimiting extends Action
         if (!$paths) {
             $paths = [];
         }
-        $validPaths = '';
 
-        foreach ($paths as $key => $value) {
-            $validPaths .= 'req.url.path ~ "' . $value->path . '" || ';
+        $validPaths = [];
+
+        foreach ($paths as $value) {
+            $validPaths[] = 'req.url.path ~ "' . $value->path . '"';
         }
-        $result = substr($validPaths, 0, strrpos($validPaths, '||', -1));
 
-        return $result;
+        return implode(' || ', $validPaths);
     }
 
     /**


### PR DESCRIPTION
This fix addresses the following error ([file](https://github.com/fastly/fastly-magento2/blob/bce65d7291b273f43ee1f1faca8fa67226aa4fe6/Controller/Adminhtml/FastlyCdn/RateLimiting/ToggleRateLimiting.php#L279)):
```
strrpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack) in (...)/Controller/Adminhtml/FastlyCdn/RateLimiting/ToggleRateLimiting.php:279
```

The reason for the error above is that `strrpos` cannot accept an offset parameter less than than 0 if the string is of zero-length which is is in the case that there are no rules defined.

Instead of appending to a string and then trying to remove the last occurrence of `||` like it is done now, we append to an array of rules and then join them with ` || ` as separator.
