### PR TITLE
Update DeleteCustomSnippet.php (fix to accept VCL name with underscore)

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/CustomSnippet/DeleteCustomSnippet.php
+++ b/Controller/Adminhtml/FastlyCdn/CustomSnippet/DeleteCustomSnippet.php
@@ -119,7 +119,7 @@ class DeleteCustomSnippet extends Action
             $write = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
             $snippetPath = $write->getRelativePath(Config::CUSTOM_SNIPPET_PATH . $snippet);
 
-            $snippetName = explode('_', $snippet);
+            $snippetName = explode('_', $snippet,3);
             $snippetName = explode('.', $snippetName[2]);
 
             $reqName = Config::FASTLY_MAGENTO_MODULE . '_' . $snippetName[0];


### PR DESCRIPTION
Current behavior:
If the custom snippet name contains an underscore (ex my_custom_vcl), then the snippet would be for instance  : **recv_100_my_custom_vcl.vcl** 
So , the snippetName return by the explode function **line 123** returns only the first part of the name (here **my**) because the explode function **line 122** split all the name parts **array("recv","100","my","custom","vcl.vcl")**.
After that, the local custom snippet is remove from the path , but the remote snippet on Fastly is never deleted because the name is wrong.

Expected behavior:
I can delete remote custom VCL even if the vcl snippet contains underscore

My fix:
I add a limit parameter (3) to the explode function on **line 122**, so that we only split in three parts (keeping the name correct even if it contains underscore)
In our previous example: the array would be: **array("recv","100","my_custom_vcl.vcl")** , so the snippet name will the be correct (**my_custom_vcl**) even if the name contains underscore.