### PR TITLE
Add check for identities type

### DIFF
--- a/Observer/InvalidateVarnishObserver.php
+++ b/Observer/InvalidateVarnishObserver.php
@@ -78,6 +78,9 @@ class InvalidateVarnishObserver implements ObserverInterface
             if ($object instanceof \Magento\Framework\DataObject\IdentityInterface && $this->canPurgeObject($object)) {
                 $tags = [];
                 foreach ($object->getIdentities() as $tag) {
+                    if (!is_string($tag)) {
+                        continue;
+                    }
                     $tag = $this->cacheTags->convertCacheTags($tag);
                     if (!in_array($tag, $this->alreadyPurged)) {
                         $tags[] = $tag;


### PR DESCRIPTION
This issue resolves an issue of `->getIdentities()` returning invalid values (particularly, null) for some models.