### PR TITLE
Allow URL encoded params to be filtered out by configuration from admin

### DIFF
--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -132,7 +132,7 @@
         # and allow custom parameters to be set. List of parameters is configurable in admin
         set req.http.Magento-Original-URL = req.url;
         # Change the list of ignored parameters by configuring them in the Advanced section
-        set req.url = querystring.regfilter(req.url, "^(####QUERY_PARAMETERS####)$");
+        set req.url = querystring.regfilter(req.url, {"^(####QUERY_PARAMETERS####)$"});
     }
 
     # Pass on checkout URLs. Because it's a snippet we want to execute this after backend selection so we handle it


### PR DESCRIPTION
We want to be able to filter out params that contain url encoded characters like ‘;' which is url-encoded to something like '%3B’.

[STRING  |  Fastly Developer Hub ](https://developer.fastly.com/reference/vcl/types/string/)
Short strings "x" decode url encoded characters, querystring.regfilter would never match anything that includes such characters.
Long strings {"x"} don’t decode url encoded characters.

Tested with Fiddle https://fiddle.fastly.dev/fiddle/1d6d6e79