### PR TITLE
Test module installation in CI

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -32,30 +32,74 @@ jobs:
   tests:
     name: "Tests"
     runs-on: ubuntu-latest
+    services:
+      db:
+        image: mariadb:10.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: magento
+          MYSQL_USER: magento
+          MYSQL_PASSWORD: magento
+        ports:
+          - 33060:3306
+        options: >-
+          --health-cmd="mysqladmin -proot ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+      es:
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.elasticsearch }}
+        env:
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+
+        ports:
+          - 9200:9200
+        options: >-
+          -e "discovery.type=single-node"
+          -e "xpack.security.enabled=false"
+          --health-cmd="curl --silent --fail localhost:9200/_cluster/health || exit 1"
+          --health-interval=30s
+          --health-timeout=30s
+          --health-retries=8
+
     strategy:
       matrix:
+        # https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html
         include:
           - magento: "2.4.0"
             php: "7.3"
             composer: "v1"
+            elasticsearch: "7.6.2"
+
           - magento: "2.4.0"
             php: "7.4"
             composer: "v1"
+            elasticsearch: "7.6.2"
+
           - magento: "2.4.1"
             php: "7.4"
             composer: "v1"
+            elasticsearch: "7.7.1"
+
           - magento: "2.4.2"
             php: "7.4"
             composer: "v1"
+            elasticsearch: "7.9.3"
+
           - magento: "2.4.3"
             php: "7.4"
             composer: "v1"
+            elasticsearch: "7.10.2"
+
           - magento: "2.4.4"
             php: "8.1"
             composer: "v2"
+            elasticsearch: "7.16.3"
+
           - magento: "2.4.5"
             php: "8.1"
             composer: "v2"
+            elasticsearch: "7.17.5"
 
     steps:
       - name: Setup PHP
@@ -85,6 +129,36 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: "app/code/Fastly/Cdn/"
+
+      - name: Setup Magento 2
+        run: |
+          echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts && \
+          bin/magento setup:install \
+          --base-url=http://magento2.test/ \
+          --db-host=127.0.0.1:33060 \
+          --db-name=magento \
+          --db-user=magento \
+          --db-password=magento \
+          --admin-firstname=admin \
+          --admin-lastname=admin \
+          --admin-email=admin@admin.com \
+          --admin-user=admin \
+          --admin-password=admin123 \
+          --language=en_US \
+          --currency=USD \
+          --timezone=America/Los_Angeles \
+          --use-rewrites=1 \
+          --search-engine=elasticsearch7 \
+          --elasticsearch-host=localhost \
+          --elasticsearch-port=9200 \
+          --elasticsearch-index-prefix=magento2 \
+          --elasticsearch-timeout=15
+
+      - name: Verify Fastly is installed in Magento
+        run: bin/magento module:status --enabled | grep -q Fastly_Cdn
+
+      - name: Compile DI
+        run: bin/magento setup:di:compile
 
       - name: Setup Problem Matcher for PHPUnit
         run: echo "::add-matcher::${{ github.workspace }}/app/code/Fastly/Cdn/.github/tests/phpunit_matcher.json"

--- a/Controller/Adminhtml/FastlyCdn/Blocking/AbstractBlocking.php
+++ b/Controller/Adminhtml/FastlyCdn/Blocking/AbstractBlocking.php
@@ -2,14 +2,13 @@
 
 namespace Fastly\Cdn\Controller\Adminhtml\FastlyCdn\Blocking;
 
-use Fastly\Cdn\Model\Config;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Config\Storage\WriterInterface as ConfigWriter;
 
 abstract class AbstractBlocking extends Action
 {
-    protected ConfigWriter $configWriter;
+    protected $configWriter;
 
     public function __construct(
         Context $context,


### PR DESCRIPTION
This PR adds testing of module installation and `setup:di:compile` to our CI testing.

It allows us to automatically test for situations where a potentially incompatible change is made to the codebase that could break in older Magento versions.

It also installs a specific version of MariaDB and ES in order to be able to install Magento 2 in the runner.