### PR TITLE
Edge dictionary batch import

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/ImportExport/GetImportData.php
+++ b/Controller/Adminhtml/FastlyCdn/ImportExport/GetImportData.php
@@ -88,17 +88,17 @@ class GetImportData extends Action
         $result = $this->resultJson->create();
         try {
             $file = $this->getRequest()->getFiles()->get('file');
-            $data = \json_decode((string)file_get_contents($file['tmp_name']));
+            $data = \json_decode((string)file_get_contents($file['tmp_name']), true);
             if (!$data) {
                 throw new LocalizedException(__('Invalid file structure'));
             }
 
             return $result->setData([
                 'status'            => true,
-                'custom_snippets'   => $data->custom_snippets,
-                'dictionaries'      => $data->edge_dictionaries,
-                'acls'              => $data->edge_acls,
-                'active_modules'    => $data->active_modules,
+                'custom_snippets'   => $data['custom_snippets'] ?? [],
+                'dictionaries'      => $data['edge_dictionaries'] ?? [],
+                'acls'              => $data['edge_acls'] ?? [],
+                'active_modules'    => $data['active_modules'] ?? [],
             ]);
         } catch (\Exception $e) {
             return $result->setData([

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -44,7 +44,7 @@ class Api
     public const PURGE_TIMEOUT        = 10;
     public const PURGE_TOKEN_LIFETIME = 30;
     public const FASTLY_MAX_HEADER_KEY_SIZE = 256;
-    public const UPSERT_ITEMS_MAX_COUNT = 100;
+    public const UPSERT_ITEMS_MAX_COUNT = 200;
 
     /**
      * @var Config

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -44,6 +44,7 @@ class Api
     public const PURGE_TIMEOUT        = 10;
     public const PURGE_TOKEN_LIFETIME = 30;
     public const FASTLY_MAX_HEADER_KEY_SIZE = 256;
+    public const UPSERT_ITEMS_MAX_COUNT = 100;
 
     /**
      * @var Config
@@ -1263,6 +1264,55 @@ class Api
 
         if (!$result) {
             throw new LocalizedException(__('Failed to create Dictionary item.'));
+        }
+    }
+
+    /**
+     * Upsert multiple Dictionary items. Do not try to send more than 100 items at a time.
+     *
+     * @param $dictionaryId
+     * @param array|object $items
+     * @throws LocalizedException
+     */
+    public function upsertDictionaryItems($dictionaryId, $items)
+    {
+        foreach (array_chunk($items, self::UPSERT_ITEMS_MAX_COUNT) as $chunk) {
+            $apiItems = [];
+            foreach ($chunk as $item) {
+                if (is_object($item)) {
+                    $itemKey = $item->item_key;
+                    $itemValue = $item->item_value;
+                } else if (is_array($item) && isset($item['item_key'], $item['item_value'])) {
+                    $itemKey = $item['item_key'];
+                    $itemValue = $item['item_value'];
+                } else {
+                    continue;
+                }
+
+                $apiItems[] = [
+                    'op' => 'upsert',
+                    'item_key' => $itemKey,
+                    'item_value' => $itemValue,
+                ];
+            }
+
+            $url = $this->_getApiServiceUri() . 'dictionary/' . rawurlencode($dictionaryId) . '/items';
+            $body = [
+                'items' => $apiItems
+            ];
+
+            $result = $this->_fetch($url, Request::METHOD_PATCH, \json_encode($body));
+
+            if (!$result) {
+                if ($this->errorMessage) {
+                    throw new LocalizedException(
+                        __('Failed to upsert Dictionary items: %1', $this->errorMessage)
+                    );
+                }
+                throw new LocalizedException(
+                    __('Failed to upsert Dictionary items')
+                );
+            }
         }
     }
 

--- a/Model/Importer.php
+++ b/Model/Importer.php
@@ -98,9 +98,7 @@ class Importer
 
         foreach ($dictionaries as $dictionary) {
             if (isset($data->{$dictionary->name}->items)) {
-                foreach ($data->{$dictionary->name}->items as $i) {
-                    $this->api->upsertDictionaryItem($dictionary->id, $i->item_key, $i->item_value);
-                }
+                $this->api->upsertDictionaryItems($dictionary->id, $data->{$dictionary->name}->items);
             }
         }
     }


### PR DESCRIPTION
This PR changes the way edge dictionary items are imported. It sends the dictionary items in batch requests of up to 200 items at once, reducing the total time needed to import the dictionary.