### PR TITLE
PE2-464: List of ignored paths - documentation update

### DIFF
--- a/Documentation/Guides/Edge-Modules/EDGE-MODULE-NETACEA-INTEGRATION.md
+++ b/Documentation/Guides/Edge-Modules/EDGE-MODULE-NETACEA-INTEGRATION.md
@@ -20,6 +20,10 @@ This is the API key provided to you by Netacea.
 
 This is the Secret provided to you by Netacea.
 
+### Netacea Ignore List
+
+This is the list of URL paths which integration will skip and won't apply any action to requests. <br />
+For example, if you put path `/skipthis` in this field then integration will skip requests coming from `www.domain.com/skipthis` and other paths that has this value as a base, like `/skipthis/mysite`.
 
 ## Enabling
 


### PR DESCRIPTION
This PR's goal is to update Netacea plugin documentation with information about new functionality that allows users to configure URL paths which integration will ignore. 