### PR TITLE
Vary on `store` cookie

### DIFF
--- a/etc/vcl_snippets/deliver.vcl
+++ b/etc/vcl_snippets/deliver.vcl
@@ -26,8 +26,8 @@
                 set resp.http.Vary = resp.http.Vary ",X-Magento-Cache-Id";
             }
         } else {
-            # Remove X-Magento-Vary and HTTPs Vary served to the user
-            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,Https", "Cookie");
+            # Remove X-Magento-Vary, X-Store-Cookie and HTTPs Vary served to the user
+            set resp.http.Vary = regsub(resp.http.Vary, "(?i)X-Magento-Vary,X-Store-Cookie,Https", "Cookie");
         }
         # Since varnish doesn't compress ESIs we need to hint to the HTTP/2 terminators to
         # compress it and we only want to do this on the edge nodes

--- a/etc/vcl_snippets/fetch.vcl
+++ b/etc/vcl_snippets/fetch.vcl
@@ -64,6 +64,7 @@
         set beresp.http.Vary:Content-Currency = "";
     } else if (beresp.http.Content-Type ~ "text/(html|xml)") {
         set beresp.http.Vary:X-Magento-Vary = "";
+        set beresp.http.Vary:X-Store-Cookie = "";
         set beresp.http.Vary:Https = "";
     }
 

--- a/etc/vcl_snippets/recv.vcl
+++ b/etc/vcl_snippets/recv.vcl
@@ -64,6 +64,13 @@
         unset req.http.X-Magento-Vary;
     }
 
+    # User's store cookie also needs to be varied upon
+    if (req.http.cookie:store) {
+        set req.http.X-Store-Cookie = req.http.cookie:store;
+    } else {
+        unset req.http.X-Store-Cookie;
+    }
+
     ############################################################################################################
     # Following code block controls purge by URL. By default we want to protect all URL purges. In general this
     # is addressed by adding Fastly-Purge-Requires-Auth request header in vcl_recv however this runs the risk of


### PR DESCRIPTION
We need to vary on `store` cookie because the first request (**MISS**) could potentially contain the cookie, resulting in every subsequent request to the same URL showing as the store of the first request. This is evident when we run multiple storeviews on the same domain.

We can see the correct behavior with this PR:

1. Make a request __with__ the store cookie present:
    ```bash
    curl -v --cookie "store=some_storeview" "https://magento-website-123.global.ssl.fastly.net/" \
        | grep -A6 'switcher-language-trigger' | tail -n 3
    ```
    output (cache **MISS**):
    ```html
    <strong class="view-default">
        <span>Some Store View</span>
    </strong>
    ```
    *Figure: request with store cookie present (we are showing the current storeview HTML)*

2. Make a request __without__ the cookie present:
    ```bash
    curl -v "https://magento-website-123.global.ssl.fastly.net/" \
        | grep -A6 'switcher-language-trigger' | tail -n 3
    ```
    output (cache **MISS**):
    ```html
    <strong class="view-default">
        <span>Default Store View</span>
    </strong>
    ```
    *Figure: request without store cookie present (we are showing the current storeview HTML)*

Previously, as the **second** response (the request **without** the cookie), we would get the same response as the **first** request (the request with the store cookie **present**), and the response would be a cache **HIT**.