### PR TITLE
Added flag parameter for testing credentials

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Configuration/TestConnection.php
+++ b/Controller/Adminhtml/FastlyCdn/Configuration/TestConnection.php
@@ -114,7 +114,8 @@ class TestConnection extends Action
                 $this->api->sendWebHook('*initiated test connection action*');
             }
 
-            $service = $this->api->checkServiceDetails(true, $serviceId, $apiKey);
+            // Set isInitialCheck flag to true - we can test credentials even if they are not saved in database
+            $service = $this->api->checkServiceDetails(true, $serviceId, $apiKey, true);
             $sendValidationReq = $this->statistic->sendValidationRequest(true, $serviceId);
             $this->saveValidationState(true, $sendValidationReq);
         } catch (\Exception $e) {

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -389,7 +389,7 @@ class Api
      */
     public function checkServiceDetails($test = false, $serviceId = null, $apiKey = null, $isInitialCheck = false)
     {
-        if (!$this->config->isServiceConfigured() && !$isInitialCheck) {
+        if (!$isInitialCheck && !$this->config->isServiceConfigured()) {
             throw new LocalizedException(__('Fastly service is not configured.'));
         }
 

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -383,12 +383,13 @@ class Api
      * @param bool $test
      * @param null $serviceId
      * @param null $apiKey
+     * @param bool $isInitialCheck - flag for testing credentials before Service ID and token are saved to config
      * @return bool|mixed
      * @throws LocalizedException
      */
-    public function checkServiceDetails($test = false, $serviceId = null, $apiKey = null)
+    public function checkServiceDetails($test = false, $serviceId = null, $apiKey = null, $isInitialCheck = false)
     {
-        if (!$this->config->isServiceConfigured()) {
+        if (!$this->config->isServiceConfigured() && !$isInitialCheck) {
             throw new LocalizedException(__('Fastly service is not configured.'));
         }
 


### PR DESCRIPTION
Credentials could not be tested before saving configuration. This closes #648.