### PR TITLE
Run init method if Fastly configuration tab is already open 

### DIFF
--- a/view/adminhtml/web/js/init.js
+++ b/view/adminhtml/web/js/init.js
@@ -14,6 +14,10 @@ define([
             let isAlreadyConfigured = true;
             let serviceStatus = false;
 
+            if (fastlyFieldset.is(':visible')) {
+                init();
+            }
+
             /**
              * Fastly Configuration head on click event
              */


### PR DESCRIPTION
This closes #659 