### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/shielding-check-cron-manual.yaml
+++ b/.github/workflows/shielding-check-cron-manual.yaml
@@ -17,10 +17,10 @@ jobs:
       run: |
         cat ./temp.json | jq . > etc/shielding/datacenters.json
         rm -f ./temp.json
-        echo "::set-output name=diff-count::$(git diff --name-only | wc -l)"
+        echo "diff-count=$(git diff --name-only | wc -l)" >> "$GITHUB_OUTPUT"
         SHA1=`sha1sum etc/shielding/datacenters.json | awk '{print $1}'`
-        echo "::set-output name=sha1::$SHA1"
-        echo "::set-output name=pr-count::$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)"
+        echo "sha1=$SHA1" >> "$GITHUB_OUTPUT"
+        echo "pr-count=$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Check diff and create PR

--- a/.github/workflows/shielding-check-cron.yaml
+++ b/.github/workflows/shielding-check-cron.yaml
@@ -20,10 +20,10 @@ jobs:
       run: |
         cat ./temp.json | jq . > etc/shielding/datacenters.json
         rm -f ./temp.json
-        echo "::set-output name=diff-count::$(git diff --name-only | wc -l)"
+        echo "diff-count=$(git diff --name-only | wc -l)" >> "$GITHUB_OUTPUT"
         SHA1=`sha1sum etc/shielding/datacenters.json | awk '{print $1}'`
-        echo "::set-output name=sha1::$SHA1"
-        echo "::set-output name=pr-count::$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)"
+        echo "sha1=$SHA1" >> "$GITHUB_OUTPUT"
+        echo "pr-count=$(gh pr list --search "${SHA1} in:title is:open" --json title -q '.[] | .title' | wc -l)" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Check diff and create PR


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter