### PR TITLE
Add flag to force enable DIO regardless of the full page cache settings

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -332,6 +332,12 @@ class Config extends \Magento\PageCache\Model\Config
         = 'system/full_page_cache/fastly/fastly_image_optimization_configuration/image_optimizations';
 
     /**
+     * XML path to image optimizations flag forced
+     */
+    const XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED
+        = 'system/full_page_cache/fastly/fastly_image_optimization_configuration/image_optimizations_forced';
+
+    /**
      * XML path to automatic compression flag
      */
     const XML_FASTLY_IMAGE_OPTIMIZATION_AUTOMATIC_COMPRESSION
@@ -828,6 +834,10 @@ class Config extends \Magento\PageCache\Model\Config
      */
     public function isImageOptimizationEnabled()
     {
+        if ($this->_scopeConfig->isSetFlag(self::XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED)) {
+            return true;
+        }
+
         if ($this->isFastlyEnabled() !== true) {
             return false;
         }

--- a/Model/Product/Image.php
+++ b/Model/Product/Image.php
@@ -78,6 +78,10 @@ class Image extends ImageModel
             $this->isFastlyEnabled = false;
         }
 
+        if ($this->_scopeConfig->isSetFlag(Config::XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED)) {
+            $this->isFastlyEnabled = true;
+        }
+
         return $this->isFastlyEnabled;
     }
 
@@ -98,6 +102,10 @@ class Image extends ImageModel
 
         if ((int)$this->_scopeConfig->getValue(PageCacheConfig::XML_PAGECACHE_TYPE) !== Config::FASTLY) {
             $this->isForceLossyEnabled = false;
+        }
+
+        if ($this->_scopeConfig->isSetFlag(Config::XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED)) {
+            $this->isFastlyEnabled = true;
         }
 
         return $this->isForceLossyEnabled;

--- a/Model/View/Asset/Image.php
+++ b/Model/View/Asset/Image.php
@@ -182,6 +182,10 @@ class Image extends ImageModel
             $this->isFastlyEnabled = false;
         }
 
+        if ($this->scopeConfig->isSetFlag(Config::XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED)) {
+            $this->isFastlyEnabled = true;
+        }
+
         return $this->isFastlyEnabled;
     }
 
@@ -202,6 +206,10 @@ class Image extends ImageModel
 
         if ((int)$this->scopeConfig->getValue(PageCacheConfig::XML_PAGECACHE_TYPE) !== Config::FASTLY) {
             $this->isForceLossyEnabled = false;
+        }
+
+        if ($this->scopeConfig->isSetFlag(Config::XML_FASTLY_IMAGE_OPTIMIZATIONS_FORCED)) {
+            $this->isFastlyEnabled = true;
         }
 
         return $this->isForceLossyEnabled;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -496,6 +496,14 @@
                             target="_blank">image optimization guide</a> for caveats and details.]]></comment>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         </field>
+                        <!-- ===============================================
+                                Force Enable Deep Image Optimization select field
+                           ================================================ -->
+                        <field id="image_optimizations_forced" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                            <label>Force Enable Deep Image Optimization</label>
+                            <comment><![CDATA[Use this to forcefully enable deep image optimisation on instances that are not connected to fastly, for use on test environments]]></comment>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        </field>
                         <!-- ====================================================
                              JPEG image quality input field
                         ===================================================== -->

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -45,6 +45,7 @@
                     </fastly_blocking>
                     <fastly_image_optimization_configuration>
                         <image_optimizations>0</image_optimizations>
+                        <image_optimizations_forced>0</image_optimizations_forced>
                         <image_optimization_force_lossy>0</image_optimization_force_lossy>
                         <image_optimization_image_quality>80</image_optimization_image_quality>
                         <image_optimization_bg_color>1</image_optimization_bg_color>


### PR DESCRIPTION
Hello 

I would like to propose an additional flag, which would allow me to enable the image optimisation settings regardless of what page cache has been configured.

My use case is as follows

We have local and ephemeral test environments spinning up for automated and manual QA. They are using a docker varnish container for full page cache rather than hooking into fastly, as this is a "good enough" measure for these temporary environments.

I want those projects and setups to have a proper look and feel, i want images to be rendered correctly at the correct sizes and compressions, to achieve this I want to do the following configuration
1. Set up the projects to have varnish for FPC
2. Set the project `web/secure/base_media_url=https://example.com/media/` so that we can load the production media on this test instance
3. Forcefully enable fastly DIO by setting `system/full_page_cache/fastly/fastly_image_optimization_configuration/image_optimizations_forced=1`, so that we can have all the appropriate resizing and compression parameters attached to the media URLs

This will give us an instance with reasonable FPC, and a good representation of the production media. This covers 99% of our test use cases, the main caveat being that anything that needs to actually test uploading images won't work. But that's an acceptable caveat I believe.

Please let me know if you would like to discuss further, I would have used a plugin to customise this on our instances but the `private function isFastlyImageOptimizationEnabled()` prevents me from doing so.

Thanks
