### PR TITLE
Catching Throwable in Blocking Controller

### DIFF
--- a/Controller/Adminhtml/FastlyCdn/Blocking/Blocking.php
+++ b/Controller/Adminhtml/FastlyCdn/Blocking/Blocking.php
@@ -174,7 +174,7 @@ class Blocking extends AbstractBlocking
             return $result->setData([
                 'status' => true
             ]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $result->setData([
                 'status'    => false,
                 'msg'       => $e->getMessage()


### PR DESCRIPTION
Switched to Throwable in catch statement because generic message was shown - error which doesn't extend Exception class was thrown