### PR TITLE
Exclude countries from rate limit

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -526,6 +526,8 @@ class Config extends \Magento\PageCache\Model\Config
     const XML_FASTLY_EXEMPT_GOOD_BOTS
         = 'system/full_page_cache/fastly/fastly_rate_limiting_settings/crawler_protection/exempt_good_bots';
 
+    const XML_FASTLY_EXCLUDED_COUNTRIES
+        = 'system/full_page_cache/fastly/fastly_rate_limiting_settings/crawler_protection/excluded_countries';
     /**
      * Request Header for VCL comparison
      */
@@ -1133,7 +1135,27 @@ class Config extends \Magento\PageCache\Model\Config
     {
         return $this->_scopeConfig->getValue(self::XML_FASTLY_EXEMPT_GOOD_BOTS);
     }
-
+    
+    /**
+     * Get the list of countries to be excluded from the rate limiting
+     *
+     * @return array
+     */
+    public function getExcludedCountries()
+    {
+        $excludedCountries = $this->_scopeConfig->getValue(self::XML_FASTLY_EXCLUDED_COUNTRIES);
+        if (!empty($excludedCountries)) {
+            try {
+                $excludedCountries = json_decode($excludedCountries, true);
+            } catch (\Exception $e) {
+                $excludedCountries = []; // Return empty array on failure
+            }
+        } else {
+            $excludedCountries = [];
+        }
+        return $excludedCountries;
+    }
+    
     /**
      * Get store ID for country.
      *

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -780,6 +780,15 @@
                             <depends>
                                 <field id="enable_rate_limiting_master">1</field>
                             </depends>
+                            <!-- =================================
+                                Exclude countries from rate limiting
+                            ================================== -->                            
+                            <field id="excluded_countries" translate="label comment" type="multiselect" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
+                                <label>Excluded Countries for Rate Limiting</label>
+                                <comment>Select countries to exclude from rate limiting.</comment>
+                                <source_model>Magento\Config\Model\Config\Source\Locale\Country</source_model>
+                                <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
+                            </field>
                         </group>
                     </group>
                     <!-- ========================

--- a/etc/vcl_snippets_rate_limiting/recv.vcl
+++ b/etc/vcl_snippets_rate_limiting/recv.vcl
@@ -8,3 +8,7 @@ if (####RATE_LIMITED_PATHS####) {
       }
   }
 }
+if (client.geo.country_code) {
+    set req.http.client-geo-country = client.geo.country_code;
+}
+


### PR DESCRIPTION
Added possibility to exclude countries from rate limit. 

Use by enable at
admin → stores → configuration → advanced → system → full page cache → fastly → fastly configuration → rate limiting → crawler bot protection →  Excluded Countries for Rate Limiting.

Rate limit needs to be enabled, as well as crawler bot protection.

Make sure cache is flushed and  new version is uploaded to fastly CDN
admin → stores → configuration → advanced → system → full page cache → fastly →  upload VCL