### PR TITLE
Update tracking tags `ignored_url_parameters`

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,7 +30,7 @@
                         <stale_ttl>86400</stale_ttl>
                         <stale_error_ttl>86400</stale_error_ttl>
                         <admin_path_timeout>180</admin_path_timeout>
-                        <ignored_url_parameters>utm_.*, gclid, gdftrk, _ga, mc_.*, trk_.*, dm_i, _ke, sc_.*, fbclid</ignored_url_parameters>
+                        <ignored_url_parameters>utm_.*, gclid, gdftrk, _ga, mc_.*, trk_.*, dm_i, _ke, sc_.*, fbclid, gbraid, wbraid, srsltid, gclsrc, dclid, gad_source</ignored_url_parameters>
                         <preserve_static>1</preserve_static>
                         <soft_purge>1</soft_purge>
                         <x_magento_tags_size>16383</x_magento_tags_size>


### PR DESCRIPTION
Coming up to black friday season it may be good to have a more complete list of default `ignored_url_parameters`

- gbraid - https://support.google.com/google-ads/answer/10417364
- wbraid -https://support.google.com/google-ads/answer/10417364
- srsltid  - https://www.rumvision.com/blog/srsltid-impacting-core-web-vitals-via-ttfb-caching/
- gclsrc - https://support.google.com/searchads/answer/6292795
- dclid https://support.google.com/campaignmanager/answer/9182069
- gad_source https://support.google.com/google-ads/answer/13327296