### PR TITLE
Fixed the issue where an incorrect DPR query string was provided in the URL after enabling the DPR feature.

### DIFF
--- a/view/frontend/web/js/gallery/gallery-mixin.js
+++ b/view/frontend/web/js/gallery/gallery-mixin.js
@@ -22,7 +22,10 @@ define([
                     if (!_.has(imageObject.fastly_srcset, wdpr))
                         return;
 
-                    imageObject.img = imageObject.fastly_srcset[wdpr];
+                    let imgSrc = imageObject.fastly_srcset[wdpr] || '',
+                        imgSrcDprRegx = new RegExp("\\s" + wdpr + "x$");
+
+                    imageObject.img = imgSrc.replace(imgSrcDprRegx, '');
                 });
 
                 this._super(config, element);

--- a/view/frontend/web/js/swatch-renderer-mixin.js
+++ b/view/frontend/web/js/swatch-renderer-mixin.js
@@ -35,7 +35,10 @@ define([
                         if (!_.has(imageObject.fastly_srcset, wdpr))
                             return;
 
-                        imageObject.img = imageObject.fastly_srcset[wdpr];
+                        let imgSrc = imageObject.fastly_srcset[wdpr] || '',
+                        imgSrcDprRegx = new RegExp("\\s" + wdpr + "x$");
+
+                        imageObject.img = imgSrc.replace(imgSrcDprRegx, '');
                     });
                 });
 


### PR DESCRIPTION
**Issue**
[Incorrect DPR query string was provided in the product image URL](https://github.com/fastly/fastly-magento2/issues/733)

**Change**
1. Added a regex replacement to correct the dpr parameter in the image URL.

