### PR TITLE
Bulk update for ACL items in CLI

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -1444,6 +1444,20 @@ class Api
         return $result;
     }
 
+    public function bulkAclItems($aclId, $aclItems)
+    {
+        $url = $this->_getApiServiceUri() . 'acl/' . rawurlencode($aclId ?? '') . '/entries' ;
+
+        // per documentation, maximum payload for bulk API is 1000
+        $chunkedItems = array_chunk($aclItems, 1000);
+
+        foreach ($chunkedItems as $items) {
+            $payload['entries'] = $items;
+
+            $this->_fetch($url, Request::METHOD_PATCH, json_encode($payload));
+        }
+    }
+
     /**
      * Update single ACL entry
      *


### PR DESCRIPTION
Implemented method which uses bulk update API for ACLs, use this logic for IP list update in fastly:maintenance command