### PR TITLE
Correct display for "fastly-page-cacheable" debug header

### DIFF
--- a/Model/Layout/LayoutPlugin.php
+++ b/Model/Layout/LayoutPlugin.php
@@ -77,7 +77,7 @@ class LayoutPlugin
             }
         }
 
-        if (empty($this->response->getHeader('fastly-page-cacheable'))) {
+        if (!empty($this->response->getHeaders()) && !$this->response->getHeaders()->has('fastly-page-cacheable')) {
             /*
              * Surface the cacheability of a page. This may expose things like page blocks being set to
              * cacheable = false which makes the whole page uncacheable

--- a/Model/Layout/LayoutPlugin.php
+++ b/Model/Layout/LayoutPlugin.php
@@ -77,14 +77,16 @@ class LayoutPlugin
             }
         }
 
-        /*
-         * Surface the cacheability of a page. This may expose things like page blocks being set to
-         * cacheable = false which makes the whole page uncacheable
-         */
-        if ($subject->isCacheable()) {
-            $this->response->setHeader("fastly-page-cacheable", "YES");
-        } else {
-            $this->response->setHeader("fastly-page-cacheable", "NO");
+        if (empty($this->response->getHeader('fastly-page-cacheable'))) {
+            /*
+             * Surface the cacheability of a page. This may expose things like page blocks being set to
+             * cacheable = false which makes the whole page uncacheable
+             */
+            if ($subject->isCacheable()) {
+                $this->response->setHeader("fastly-page-cacheable", "YES");
+            } else {
+                $this->response->setHeader("fastly-page-cacheable", "NO");
+            }
         }
     }
 

--- a/Model/Layout/LayoutPlugin.php
+++ b/Model/Layout/LayoutPlugin.php
@@ -77,7 +77,7 @@ class LayoutPlugin
             }
         }
 
-        if (!empty($this->response->getHeaders()) && !$this->response->getHeaders()->has('fastly-page-cacheable')) {
+        if (empty($this->response->getHeader('fastly-page-cacheable'))) {
             /*
              * Surface the cacheability of a page. This may expose things like page blocks being set to
              * cacheable = false which makes the whole page uncacheable


### PR DESCRIPTION
Check if fastly-page-cacheable is already set - prevent overriding initial value with dynamic content