### PR TITLE
Make "/pub" optional when skipping basic auth on static requests

### DIFF
--- a/etc/vcl_snippets_basic_auth/recv.vcl
+++ b/etc/vcl_snippets_basic_auth/recv.vcl
@@ -4,6 +4,6 @@
       table.lookup(magentomodule_basic_auth, regsub(req.http.Authorization, "^Basic ", ""), "NOTFOUND") == "NOTFOUND" &&
       !req.url ~ "^/(index\.php/)?####ADMIN_PATH####/" &&
       !req.url ~ "^/(index\.php/)?(rest|oauth|graphql)($|[\/?])" &&
-      !req.url ~ "^/pub/static/" ) {
+      !req.url ~ "^/(pub/)?static/" ) {
       error 771;
   }


### PR DESCRIPTION
The current configuration only supports the case when the document root is configured to Magento root directory. Meanwhile, Magento recommends using `pub` directory as a document root. Please see this doc for more details.

https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/docroot

In case `"document_root_is_pub" => true`, which is the default value for new Magento installations, static requests do not include `/pub` prefix, and the basic auth skip condition does not work for them. 

This change makes `/pub` prefix optional to support both configurations.