### PR TITLE
Custom class for Country options

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -104,6 +104,10 @@ jobs:
           composer create-project --repository-url="https://mirror.mage-os.org/" \
           "magento/project-community-edition=${{ matrix.magento }}" . --no-install
 
+      - name: Ignore specific security advisories
+        run: |
+          composer config --json audit.ignore '{"PKSA-7h5p-prw9-w5nr": "advisory is time complexity related, low impact for our scenario"}'
+
       - name: Force PHPUnit version
         if: matrix.phpunit != ''
         run: composer require --no-install --dev "phpunit/phpunit:${{ matrix.phpunit }}"

--- a/Model/Config/Country.php
+++ b/Model/Config/Country.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Fastly\Cdn\Model\Config;
+
+class Country extends \Magento\Directory\Model\Config\Source\Country
+{
+
+    public function toOptionArray($isMultiselect = false, $foregroundCountries = '')
+    {
+        $options = parent::toOptionArray($isMultiselect, $foregroundCountries);
+
+        // Introduced custom class so we can update countries list if there is a mismatch between Magento and Fastly options
+        $additionalCountries = [
+            [
+                'value' => 'PR',
+                'label' => 'Puerto Rico',
+            ]
+        ];
+
+        $options = array_merge($options, $additionalCountries);
+        return $options;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -335,7 +335,7 @@
                             <comment>
                                 <![CDATA[List of countries that can be selected. Multiple selections allowed.]]>
                             </comment>
-                            <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                            <source_model>Fastly\Cdn\Model\Config\Country</source_model>
                             <can_be_empty>1</can_be_empty>
                         </field>
                         <!-- ==========================


### PR DESCRIPTION
Using custom class for country options in Blocking feature - mismatch between default Magento country list and Fastly options. This closes #809 